### PR TITLE
task: repoint task-workdir refs tasks/ → .oh/tasks/

### DIFF
--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -51,7 +51,7 @@ no hand-run probe, no bespoke staleness scorer). If a skill owns it, you invoke 
 <!-- auditor-scope-boundary -->
 **The auditor MANAGES — it never reimplements — the seven audit skills: it routes to
 `/harness-audit` (whole-harness health via 4 parallel auditors), `/pr-audit` (the entire
-open-PR queue in one bulk query), `/audit` (ONE implementation vs its `tasks/<slug>/prd.json`),
+open-PR queue in one bulk query), `/audit` (ONE implementation vs its `.oh/tasks/<slug>/prd.json`),
 `/context-audit` (the default-loaded context budget), `/skill-lint` (skill staleness),
 `/drift-check` (origin↔upstream / branch-behind / cron-staleness drift), and `/eval` (the
 deterministic `evals/probes/*.sh` suite); it is orthogonal to the `critic` agent, which
@@ -78,7 +78,7 @@ non-overlapping reason the family exists.
 |-------|--------------------------|--------------------|-----------|----------------|
 | `/harness-audit` | The whole harness (4 parallel PM/Implementer/Critic/Explorer auditors) | Tier 1/2/3 + Next 3 Actions | read-only (spawns agents) | PRs; one implementation |
 | `/pr-audit` | The entire open-PR queue (one `gh pr list --json`) | bucket per PR (ready / CI-fail / conflict / draft …) | read-only by default; `--proof`/`--label-apply`/`--close-stale` mutate | diff-level correctness (→ `/code-review`) |
-| `/audit` | ONE implementation vs its `tasks/<slug>/prd.json` | `AUDIT-PASS` / `AUDIT-FAIL` (names the gate) | read-only | the harness; the queue |
+| `/audit` | ONE implementation vs its `.oh/tasks/<slug>/prd.json` | `AUDIT-PASS` / `AUDIT-FAIL` (names the gate) | read-only | the harness; the queue |
 | `/context-audit` | The default-loaded context budget | `KEEP` / `TRIM` / `DEMOTE` / `CUT` (+ Tier-2 ablation) | read-only (ablation restores) | on-demand context |
 | `/skill-lint` | Skill staleness across 5 dimensions | `CURRENT` / `STALE` / `BROKEN` / `DELETE` | read-only | skill logic bugs |
 | `/drift-check` | Framework / branch-behind / cron-staleness drift | `OK` per class, else `DRIFT:` aggregate | read-only (only `git fetch`) | remediation (reports, never fixes) |
@@ -304,7 +304,7 @@ is surfaced rather than double-counted.
 **Action**: Decline within the audit family and redirect — diff-level correctness is
 `/code-review`, not the queue-level `/pr-audit`. Offer the in-family adjacent: `/pr-audit`
 (or `/pr-audit --deep` PR #312) for *triage/CI/mergeability*, and `/audit <slug>` if #312 has
-a `tasks/<slug>/prd.json` and you want a per-unit PASS/FAIL. State the boundary explicitly so
+a `.oh/tasks/<slug>/prd.json` and you want a per-unit PASS/FAIL. State the boundary explicitly so
 the user picks the right surface.
 
 ## Registration

--- a/skills/approve/SKILL.md
+++ b/skills/approve/SKILL.md
@@ -23,9 +23,9 @@ routes on.
 
 **Core principle: gate the spec before anything is committed.** This embodies
 critic-before-commitment: the cheapest thing to revise is the spec itself, so the
-gate runs while ONLY local artifacts exist (`tasks/<slug>/prd.md`, `prd.json`,
+gate runs while ONLY local artifacts exist (`.oh/tasks/<slug>/prd.md`, `prd.json`,
 `critique.md`) — **before** the GitHub issue, branch, or PR. A `DENIED` is therefore
-fully reversible (`rm -rf tasks/<slug>/`); no GitHub-side state is created until
+fully reversible (`rm -rf .oh/tasks/<slug>/`); no GitHub-side state is created until
 after `APPROVED`. (Mirrors `/ship-spec` Stage 4, which encodes the same HALT gate
 inline; this node makes it a reusable decision.)
 
@@ -40,14 +40,14 @@ run the critics itself — if `critique.md` is absent, the gate cannot decide (s
 
 | Arg | Meaning |
 |-----|---------|
-| `<slug>` | The task slug — locates `tasks/<slug>/critique.md` (the critic findings) and `tasks/<slug>/prd.md`. Required. |
+| `<slug>` | The task slug — locates `.oh/tasks/<slug>/critique.md` (the critic findings) and `.oh/tasks/<slug>/prd.md`. Required. |
 | `--auto` | Unattended mode (e.g. under `/autopilot`): never prompt a human; the SEVERITY auto-gate alone decides. Without it, a borderline finding may surface an `AskUserQuestion` override (see gate). |
 
 ---
 
 ## The gate
 
-Read `tasks/<slug>/critique.md`. The critics write findings in the established
+Read `.oh/tasks/<slug>/critique.md`. The critics write findings in the established
 shape (`/ship-spec` Stage 3):
 
 ```
@@ -84,7 +84,7 @@ unresolved high-severity finding is `DENIED`. Never auto-approve a borderline hi
 |---|---|
 | `APPROVED` → `implement` | `DENIED` → `plan` (revise the PRD and re-critique) |
 
-On `DENIED`, name the blocking finding(s) and point at `tasks/<slug>/critique.md` so
+On `DENIED`, name the blocking finding(s) and point at `.oh/tasks/<slug>/critique.md` so
 the `plan` node knows exactly what to revise. The revision is local-only — nothing
 GitHub-side exists yet.
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -40,7 +40,7 @@ is a downstream concern and remediation belongs to the build step on
 
 | Arg | Meaning |
 |-----|---------|
-| `<slug>` | The task slug — locates `tasks/<slug>/prd.json` and `tasks/<slug>/progress.txt`. Required. |
+| `<slug>` | The task slug — locates `.oh/tasks/<slug>/prd.json` and `.oh/tasks/<slug>/progress.txt`. Required. |
 | `--pr <N>` | The PR for this unit, if one exists. When set, gate 3 uses `/pr-audit` (which reads `statusCheckRollup`, subsuming `/ci-status`). |
 | `--branch <branch>` | The work branch. Used by gate 3's `/ci-status` fallback when there is no PR yet (e.g. an autopilot pre-PR audit). Defaults to the current branch. |
 
@@ -60,7 +60,7 @@ Every user story in the task graph must be marked complete. The ralph loop flips
 when **zero** stories remain unfinished:
 
 ```bash
-SLUG="$1"; PRD="tasks/$SLUG/prd.json"
+SLUG="$1"; PRD=".oh/tasks/$SLUG/prd.json"
 [ -f "$PRD" ] || { echo "FAIL gate1: no $PRD"; exit 1; }
 unfinished=$(jq '[.userStories[] | select(.passes != true)] | length' "$PRD")
 total=$(jq '.userStories | length' "$PRD")
@@ -105,7 +105,7 @@ If the task graph contains any browser-verification criteria, the UI must be
 confirmed visually:
 
 ```bash
-grep -qi "agent-browser\|Verify in browser" "tasks/$SLUG/prd.json" && echo "UI gate applies"
+grep -qi "agent-browser\|Verify in browser" ".oh/tasks/$SLUG/prd.json" && echo "UI gate applies"
 ```
 
 When it applies, drive `/agent-browser` against the running app for the changed

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -128,10 +128,10 @@ log_liveness() { mkdir -p "$AUTOPILOT_LOG_ROOT/crons"; printf '[%s] autopilot: %
 # SH_WORD_SPLIT by default) — either way the clean check matches nothing and is
 # vacuously satisfied. The array form "${OWNED_PATHS[@]}" expands correctly in both.
 # Write-surface cross-check (known-complete): every tracked path autopilot writes in
-# §2–§7 is within OWNED_PATHS — tasks/, evals/, memory/, CHANGELOG.md, and .claude/ are
+# §2–§7 is within OWNED_PATHS — .oh/tasks/, evals/, memory/, CHANGELOG.md, and .claude/ are
 # the autopilot-written tracked dirs, all in the set — else it is committed by the
 # selected executor on the feature branch or lives under /tmp. No autopilot write lands outside this surface.
-OWNED_PATHS=(.claude/ context/ docs/ scripts/ crons/ .mifune/skills/wiki/ evals/ memory/ tasks/ CHANGELOG.md)
+OWNED_PATHS=(.claude/ context/ docs/ scripts/ crons/ .mifune/skills/wiki/ evals/ memory/ .oh/tasks/ CHANGELOG.md)
 
 # Isolated worktree mode (worktree:true cron — the DEFAULT for autopilot): the cron
 # runtime fired this run inside a fresh detached worktree ($CRON_WORKTREE) cut from the
@@ -411,13 +411,13 @@ Dispatch by executor. In the `ship-spec`/`delegate-advisor` deferring modes `/sh
 
 **Delegate-advisor failure compensation** — if `/ship-spec` returns `DRAFT-BLOCKED` because its implement/`/delegate` phase failed, stalled, or left acceptance criteria incomplete (eval/CI reds are reconciled in §6/§7):
 ```bash
-gh pr comment "$PR_NUM" --repo "$AUTOPILOT_REPO" --body "autopilot: /ship-spec did not complete tasks/$SLUG/prd.json (implement/delegate phase). PR left draft; attach to tmux session $SESSION (or agent-ship-$SLUG) and resume. Status: DELEGATE-FAIL."
+gh pr comment "$PR_NUM" --repo "$AUTOPILOT_REPO" --body "autopilot: /ship-spec did not complete .oh/tasks/$SLUG/prd.json (implement/delegate phase). PR left draft; attach to tmux session $SESSION (or agent-ship-$SLUG) and resume. Status: DELEGATE-FAIL."
 ```
 - Memory log `Result: DELEGATE-FAIL`, liveness `DELEGATE-FAIL`, **persist the session** (`[ -n "$KEEP" ] && touch "$KEEP"`), leave `ACTIVE_MARKER` in place for duplicate suppression, the canonical scoped restore (`git checkout development -- "${OWNED_PATHS[@]}"` then `git checkout development`, then assert `git diff --quiet -- "${OWNED_PATHS[@]}" && git diff --cached --quiet -- "${OWNED_PATHS[@]}" || { echo "ERROR: autopilot restore left a dirty owned tree"; exit 1; }` and `[ "$(git rev-parse --abbrev-ref HEAD)" = "development" ] || exit 1`), exit 1 (non-destructive — never auto-close the issue or PR).
 
 #### `delegate-advisor` — defer to `/ship-spec` with the `/delegate` worker fan-out
 
-Same deferral as `ship-spec`, but autopilot passes `--executor=delegate-advisor` to `/ship-spec`, so Stage 10 uses the legacy `/delegate --plan tasks/<slug>/prd.json` worker fan-out instead of the Advisor-monitored ralph loop. Autopilot still does **not** run its own `/compact`/`/delegate`/`/eval`; the same delegate-advisor failure compensation above applies. Reconcile in §6/§7.
+Same deferral as `ship-spec`, but autopilot passes `--executor=delegate-advisor` to `/ship-spec`, so Stage 10 uses the legacy `/delegate --plan .oh/tasks/<slug>/prd.json` worker fan-out instead of the Advisor-monitored ralph loop. Autopilot still does **not** run its own `/compact`/`/delegate`/`/eval`; the same delegate-advisor failure compensation above applies. Reconcile in §6/§7.
 
 #### `ralph` fallback (legacy inline)
 
@@ -427,13 +427,13 @@ When `EXECUTOR=ralph` (from `--executor=ralph` or `AUTOPILOT_EXECUTOR=ralph`), b
 .oh/scripts/ralph.sh "$SLUG"
 ```
 
-Then **bash-poll** `tasks/$SLUG/progress.txt` for the terminal sentinel. Each round is bounded under the Bash tool ceiling; **re-run the round** until it reports `RALPH: DONE` or `RALPH: SESSION-GONE`, up to ~8 rounds (~64 min wall-clock):
+Then **bash-poll** `.oh/tasks/$SLUG/progress.txt` for the terminal sentinel. Each round is bounded under the Bash tool ceiling; **re-run the round** until it reports `RALPH: DONE` or `RALPH: SESSION-GONE`, up to ~8 rounds (~64 min wall-clock):
 
 ```bash
 # one poll round — re-run until it prints RALPH: DONE or RALPH: SESSION-GONE
 end=$(( $(date +%s) + 480 ))
 while [ "$(date +%s)" -lt "$end" ]; do
-  grep -q '^STATUS: COMPLETE' "tasks/$SLUG/progress.txt" && { echo "RALPH: DONE"; break; }
+  grep -q '^STATUS: COMPLETE' ".oh/tasks/$SLUG/progress.txt" && { echo "RALPH: DONE"; break; }
   tmux has-session -t "$SLUG" 2>/dev/null || { echo "RALPH: SESSION-GONE"; break; }
   sleep 30
 done
@@ -445,7 +445,7 @@ done
 **Ralph-incomplete compensation** — the partial implementation is committed on the branch and the four-file task state is resumable:
 ```bash
 tmux kill-session -t "$SLUG" 2>/dev/null || true
-gh pr comment "$PR_NUM" --repo "$AUTOPILOT_REPO" --body "autopilot: Ralph loop did not reach STATUS: COMPLETE (timeout / exhausted / error). PR left draft; tasks/$SLUG/ state is resumable — re-run \`.oh/scripts/ralph.sh $SLUG\` to continue. Status: RALPH-INCOMPLETE."
+gh pr comment "$PR_NUM" --repo "$AUTOPILOT_REPO" --body "autopilot: Ralph loop did not reach STATUS: COMPLETE (timeout / exhausted / error). PR left draft; .oh/tasks/$SLUG/ state is resumable — re-run \`.oh/scripts/ralph.sh $SLUG\` to continue. Status: RALPH-INCOMPLETE."
 ```
 - Memory log `Result: RALPH-INCOMPLETE`, liveness `RALPH-INCOMPLETE`, **persist the session** (`[ -n "$KEEP" ] && touch "$KEEP"`), leave `ACTIVE_MARKER` in place for duplicate suppression, the canonical scoped restore (`git checkout development -- "${OWNED_PATHS[@]}"` then `git checkout development`, then assert `git diff --quiet -- "${OWNED_PATHS[@]}" && git diff --cached --quiet -- "${OWNED_PATHS[@]}" || { echo "ERROR: autopilot restore left a dirty owned tree"; exit 1; }` and `[ "$(git rev-parse --abbrev-ref HEAD)" = "development" ] || exit 1`), exit 1 (non-destructive — never auto-close the issue or PR).
 
@@ -513,7 +513,7 @@ git push "$AUTOPILOT_REMOTE" HEAD
 
 **Release the overlap lock before restoring** (mandatory for kept Pi sessions): after any terminal PR state (`PR-READY`, `PR-DRAFT-CI-RED`, or `PR-DRAFT-EVAL-RED`), run `release_overlap_lock` before the restore. Kept Pi sessions intentionally stay alive for manual review, so the cron wrapper may not regain control to remove `/tmp/cron-autopilot.pid`; the skill must clear `$CRON_OVERLAP_PIDFILE` itself once the run is terminal. Incomplete executor paths (`DELEGATE-FAIL`, `RALPH-INCOMPLETE`) keep the lock because manual continuation is expected.
 
-**Restore branch** (root mode only — when `$CRON_WORKTREE` is set the whole restore is skipped: a worktree run never touched root and its worktree is discarded by the runtime/heartbeat, so there is nothing to restore. In root mode it is mandatory — the next cron fire's §1 branch guard only passes on `development`). Canonical **scoped restore** — a non-destructive two-step that discards only this run's own OWNED-path residue, then switches HEAD. Committed work is safe on the branch / draft PR. The scope step MUST precede the branch switch (it clears owned residue that would otherwise make a non-forced `git checkout development` refuse). It touches only **tracked** files, so an untracked owned-path orphan from a mid-run crash is NOT auto-removed (`git clean` is deliberately NOT used — too destructive across `tasks/`, `memory/`, `.claude/`); clean such orphans manually. Any **foreign** change OUTSIDE the owned surface — modified or staged (e.g. `.codex/config.toml`) — survives byte-for-byte (left in place / left staged) and is ignored by the scoped assertion and the next §1 check:
+**Restore branch** (root mode only — when `$CRON_WORKTREE` is set the whole restore is skipped: a worktree run never touched root and its worktree is discarded by the runtime/heartbeat, so there is nothing to restore. In root mode it is mandatory — the next cron fire's §1 branch guard only passes on `development`). Canonical **scoped restore** — a non-destructive two-step that discards only this run's own OWNED-path residue, then switches HEAD. Committed work is safe on the branch / draft PR. The scope step MUST precede the branch switch (it clears owned residue that would otherwise make a non-forced `git checkout development` refuse). It touches only **tracked** files, so an untracked owned-path orphan from a mid-run crash is NOT auto-removed (`git clean` is deliberately NOT used — too destructive across `.oh/tasks/`, `memory/`, `.claude/`); clean such orphans manually. Any **foreign** change OUTSIDE the owned surface — modified or staged (e.g. `.codex/config.toml`) — survives byte-for-byte (left in place / left staged) and is ignored by the scoped assertion and the next §1 check:
 ```bash
 release_overlap_lock                         # terminal PR state reached; clear cron overlap lock before keeping the Pi session alive
 if [ -z "${CRON_WORKTREE:-}" ]; then         # root mode ONLY — a worktree run is ephemeral (runtime/heartbeat removes the worktree); there is nothing in root to restore
@@ -572,8 +572,8 @@ See `.mifune/skills/retro/references/memory-protocol.md` for the canonical Memor
 | `PR-DRAFT-CI-RED` | PR left draft because the PR was not promotable per `/pr-audit` (CI red/pending or conflicts) — set by `/ship-spec` in the ship-spec/delegate-advisor modes, or by the ralph fallback's own `/pr-audit` gate |
 | `PR-DRAFT-EVAL-RED` | PR left draft because `/eval` reported a NEW (green→red) probe regression or a non-zero runner exit (inside `/ship-spec` in the ship-spec/delegate-advisor modes, or autopilot's inline `/eval` in ralph mode) |
 | `HALT-CRITIC-GATE` | `/ship-spec` critic gate rejected the spec; ticket labeled `autopilot-blocked`, no PR opened |
-| `RALPH-INCOMPLETE` | §5 Ralph fallback loop did not reach `STATUS: COMPLETE` (timeout, loop died, or all harnesses exhausted) after `/ship-spec` opened a PR; PR left draft — `tasks/$SLUG/` state is resumable via `.oh/scripts/ralph.sh $SLUG` |
-| `DELEGATE-FAIL` | `/ship-spec`'s implement phase (the Advisor-monitored ralph loop, or the `/delegate` fan-out under `--executor=delegate-advisor`) failed or stalled on `tasks/$SLUG/prd.json` in the ship-spec/delegate-advisor modes; PR left draft and the `autopilot-<branch>` / `agent-ship-<slug>` session is left alive for manual continuation |
+| `RALPH-INCOMPLETE` | §5 Ralph fallback loop did not reach `STATUS: COMPLETE` (timeout, loop died, or all harnesses exhausted) after `/ship-spec` opened a PR; PR left draft — `.oh/tasks/$SLUG/` state is resumable via `.oh/scripts/ralph.sh $SLUG` |
+| `DELEGATE-FAIL` | `/ship-spec`'s implement phase (the Advisor-monitored ralph loop, or the `/delegate` fan-out under `--executor=delegate-advisor`) failed or stalled on `.oh/tasks/$SLUG/prd.json` in the ship-spec/delegate-advisor modes; PR left draft and the `autopilot-<branch>` / `agent-ship-<slug>` session is left alive for manual continuation |
 | `SPAWNED_WORKTREE` | Emitted by the cron runtime (not this skill): a `worktree: true` fire spawned in an isolated `.worktrees/cron/<session>` worktree (the default for autopilot) so the root checkout stays clean |
 | `SKIPPED_OVERLAP` | Emitted by the cron runtime (not this skill): a previous fire of this id was still running with `overlap: false`. **No longer reachable for autopilot** (`worktree: true` always isolates instead of skipping); retained for non-worktree crons (heartbeat/cleanup/eval) |
 | `ERR_WORKTREE` | Emitted by the cron runtime (not this skill): a `worktree: true` fire could not create its isolated worktree (no base ref, or `git worktree add` failed). A surfaced FAILURE, never a silent skip |

--- a/skills/caveman-compress/SKILL.md
+++ b/skills/caveman-compress/SKILL.md
@@ -21,7 +21,7 @@ In-scope targets only:
 
 Everything else is **out of scope** — refuse with a one-line reason. In particular:
 - `docs/**`, `README.md`, `CLAUDE.md`/`AGENTS.md` — published / load-bearing prose; brevity is intentional there.
-- `tasks/archive/**` and other archives — not read by default; compressing is busywork that mutates the record for ~0 live-token gain.
+- `.oh/tasks/archive/**` and other archives — not read by default; compressing is busywork that mutates the record for ~0 live-token gain.
 - `context/**`, `.claude/skills/**`, `.claude/agents/**` — auto-loaded / behavior-steering. Token budget there is `/context-audit`'s job (it has a safe ablation gate); compression here can silently change behavior.
 
 ## Procedure

--- a/skills/critique/SKILL.md
+++ b/skills/critique/SKILL.md
@@ -3,7 +3,7 @@ name: critique
 description: >-
   The critique node of the canonical workflow — run two adversarial critics in
   parallel (implementer lens + user lens) against a freshly-planned spec, write
-  their findings to tasks/<slug>/critique.md, and hand off to the approve gate.
+  their findings to .oh/tasks/<slug>/critique.md, and hand off to the approve gate.
   This is the EVIDENCE half of the critique→approve pair; it produces findings,
   it does not decide (the /approve gate decides). Runs on local artifacts only,
   before any GitHub-side state.
@@ -20,7 +20,7 @@ the short adversarial feedback loop on a planned spec *before* anything is commi
 and writes the `critique.md` artifact the `approve` gate then decides on.
 
 **Core principle: surface risk while the spec is still the cheapest thing to revise.**
-Two critics with **different framings** review `tasks/<slug>/prd.md` in parallel —
+Two critics with **different framings** review `.oh/tasks/<slug>/prd.md` in parallel —
 symmetric critics waste context. Every finding is SEVERITY-tagged so the downstream
 `/approve` gate can act on it mechanically. This node produces evidence; it does not
 gate (that is `/approve`). Like the gate, it touches only local artifacts — no
@@ -33,9 +33,9 @@ reusable node.
 
 | Arg | Meaning |
 |-----|---------|
-| `<slug>` | The task slug — the critics read `tasks/<slug>/prd.md`; output is written to `tasks/<slug>/critique.md`. Required. |
+| `<slug>` | The task slug — the critics read `.oh/tasks/<slug>/prd.md`; output is written to `.oh/tasks/<slug>/critique.md`. Required. |
 
-If `tasks/<slug>/prd.md` is absent there is nothing to critique — print an error
+If `.oh/tasks/<slug>/prd.md` is absent there is nothing to critique — print an error
 pointing at `/spec plan` and emit **no** `STATUS:` token (honest exits: a missing
 spec is a failure, not a clean critique).
 
@@ -52,11 +52,11 @@ have caught the v0.7 convergence regression, PR #212 / US-012).
 ### Critic A — Implementer lens
 
 > You are an adversarial implementer reviewing a PRD before any code is written. Read
-> `tasks/<slug>/prd.md`. Read `.claude/protected-paths.txt` and treat its entries as
+> `.oh/tasks/<slug>/prd.md`. Read `.claude/protected-paths.txt` and treat its entries as
 > MUST-NOT-DELETE without an override note. Surface technical risks BEFORE
 > implementation. Focus on: (1) vague/unverifiable acceptance criteria; (2) missing
 > dependencies each story silently assumes; (3) pattern conflicts with this repo (read
-> `AGENTS.md` + the relevant `.mifune/skills/*/SKILL.md` and sibling `tasks/*/prd.json`); (4) scope creep — "single
+> `AGENTS.md` + the relevant `.mifune/skills/*/SKILL.md` and sibling `.oh/tasks/*/prd.json`); (4) scope creep — "single
 > iteration" stories that are really 2+; (5) hidden destructive operations not
 > explicitly gated; (6) protected-path violations → `SEVERITY: H` + `[PROTECTED-PATH]`.
 > Return:
@@ -68,7 +68,7 @@ have caught the v0.7 convergence regression, PR #212 / US-012).
 ### Critic B — User lens
 
 > You are an adversarial user reviewing a PRD before implementation. Read
-> `tasks/<slug>/prd.md` and `context/USER.md` (the single-developer / single-project
+> `.oh/tasks/<slug>/prd.md` and `context/USER.md` (the single-developer / single-project
 > framing). Read `.claude/protected-paths.txt` and treat its entries as MUST-NOT-DELETE
 > without an override note. Surface scope and framing risks BEFORE the team commits.
 > Focus on: (1) scope ambiguity — what's missing from Non-Goals; (2) audience
@@ -106,7 +106,7 @@ Invariants (the seam is schema-preserving):
 
 ---
 
-## Write `tasks/<slug>/critique.md`
+## Write `.oh/tasks/<slug>/critique.md`
 
 Persist both critics' raw output plus a synthesis, in the exact shape `/approve` (and
 `/ship-spec` Stage 4) parses:

--- a/skills/eval/SKILL.md
+++ b/skills/eval/SKILL.md
@@ -62,7 +62,7 @@ code by design — this is not a bug.
 target rule/memory file loaded (reusing `scripts/ablate.sh`'s swap/restore/trap
 mechanics — NOT the `claude -p` oracle) and reports `LOAD-BEARING` (regression on
 removal) or `PRUNABLE`. This is the prune-half of the fitness function. See
-US-006 in `tasks/context-fitness-evals/prd.md`.
+US-006 in `.oh/tasks/context-fitness-evals/prd.md`.
 
 ## When NOT to use
 

--- a/skills/harness-context/SKILL.md
+++ b/skills/harness-context/SKILL.md
@@ -19,7 +19,7 @@ conventions, git workflow, or where files live.
 1. Read `CLAUDE.md` for the orchestrator contract — what the root-level
    agent does and does not do.
 2. For layout questions, read the per-directory `README.md` files (e.g.
-   `.oh/README.md`, `crons/README.md`, `tasks/README.md`,
+   `.oh/README.md`, `crons/README.md`, `.oh/tasks/README.md`,
    `.oh/scripts/README.md`, `.worktrees/README.md`) and the `Project
    Structure` section of `CLAUDE.md`. There is no single comprehensive
    tree — use the filesystem and the directory READMEs.

--- a/skills/imagine/SKILL.md
+++ b/skills/imagine/SKILL.md
@@ -146,7 +146,7 @@ Then run the qualify/improve loop per `.mifune/skills/retro/references/memory-pr
 - **Asking clarifying questions.** Breaks the one-shot contract. If the scenario is too vague, push the ambiguities into `## Open questions for /prd`; do not interrupt.
 - **Writing a full PRD.** Story seeds are one-liners. Numbered functional requirements, acceptance criteria, success metrics — all `/prd`'s job, not this skill's.
 - **Skipping the mermaid diagram.** The diagram is the cheapest forcing function for "did I actually understand the scenario?" Pick a real type; never emit a placeholder or `// TODO: diagram`.
-- **Writing outside `.claude/specs/<slug>/`.** No spillover into `tasks/`, `memory/<topic>.md`, `.mifune/skills/wiki/corpus/`, or root. Those surfaces have their own skills.
+- **Writing outside `.claude/specs/<slug>/`.** No spillover into `.oh/tasks/`, `memory/<topic>.md`, `.mifune/skills/wiki/corpus/`, or root. Those surfaces have their own skills.
 - **Auto-chaining into `/ship-spec`.** Keep the seam explicit. The user edits the spec before formalizing — that's the entire reason the seam exists.
 - **Truncating the scenario into the slug.** `imagine a long thirty word scenario about ...` → derive the noun phrase (`thirty-word-scenario` or `long-scenario`), not the first five words verbatim.
 

--- a/skills/prd/SKILL.md
+++ b/skills/prd/SKILL.md
@@ -14,7 +14,7 @@ Create detailed Product Requirements Documents that are clear, actionable, and s
 1. Receive a feature description from the user
 2. Ask 3-5 essential clarifying questions (with lettered options)
 3. Generate a structured PRD based on answers
-4. Save to `tasks/<feature-name>/prd.md`
+4. Save to `.oh/tasks/<feature-name>/prd.md`
 
 **Important:** Do NOT start implementing. Just create the PRD.
 
@@ -150,7 +150,7 @@ The PRD reader may be a junior developer or AI agent. Therefore:
 ## Output
 
 - **Format:** Markdown (`.md`)
-- **Location:** `tasks/<feature-name>/`
+- **Location:** `.oh/tasks/<feature-name>/`
 - **Filename:** `prd.md`
 - **Feature name (`<short-desc>`):** lowercase kebab-case, `[a-z0-9-]+`, **≤5 words** (per `.claude/skills/git/SKILL.md` — this slug becomes the `<short-desc>` segment in any branch the task produces). Slugify the user-supplied name:
   - Lowercase everything
@@ -165,7 +165,7 @@ The PRD reader may be a junior developer or AI agent. Therefore:
   | `Slack thread replies` | `slack-thread-replies` |
   | `Add a long six word feature` | rejected — exceeds 5 words |
   | `archive` | rejected — `archive` is reserved |
-- **Rerun:** if `tasks/<feature-name>/prd.md` already exists, overwrite in place. The PRD is a living spec; git history is the recovery path.
+- **Rerun:** if `.oh/tasks/<feature-name>/prd.md` already exists, overwrite in place. The PRD is a living spec; git history is the recovery path.
 
 ---
 
@@ -276,4 +276,4 @@ Before saving the PRD:
 - [ ] Functional requirements are numbered and unambiguous
 - [ ] Non-goals section defines clear boundaries
 - [ ] Feature name is lowercase kebab-case (`[a-z0-9-]+`, not `archive`)
-- [ ] Saved to `tasks/<feature-name>/prd.md`
+- [ ] Saved to `.oh/tasks/<feature-name>/prd.md`

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -11,11 +11,11 @@ Converts existing PRDs to the prd.json format that Ralph uses for autonomous exe
 
 ## The Job
 
-Convert `tasks/<short-desc>/prd.md` to `tasks/<short-desc>/prd.json` in the same folder.
+Convert `.oh/tasks/<short-desc>/prd.md` to `.oh/tasks/<short-desc>/prd.json` in the same folder.
 
 Required arguments:
 
-- Folder path (positional, e.g. `tasks/install-prereq-detection/`). The folder name is `<short-desc>`.
+- Folder path (positional, e.g. `.oh/tasks/install-prereq-detection/`). The folder name is `<short-desc>`.
 - `--issue <N>` — GitHub issue number this PRD addresses. Required. The branch name embeds this.
 - `--prefix <type>` — branch prefix per `.claude/skills/git/SKILL.md`. One of `feat | bug | task | audit | skill | agent`. Default: `feat`.
 
@@ -25,7 +25,7 @@ Required arguments:
 <prefix>/<issue#>-<short-desc>
 ```
 
-Example: folder `tasks/install-prereq-detection/` + `--issue 175` + `--prefix task` → `branchName: "task/175-install-prereq-detection"`.
+Example: folder `.oh/tasks/install-prereq-detection/` + `--issue 175` + `--prefix task` → `branchName: "task/175-install-prereq-detection"`.
 
 If `--issue` is missing, hard-fail with: "issue number required — open the GitHub issue first per `.claude/skills/git/SKILL.md` and re-run with `--issue <N>`." This matches the project's "issue first, then branch" workflow.
 
@@ -264,7 +264,7 @@ Add ability to mark tasks with different statuses.
 
 ## Archiving Previous Runs
 
-Archive fires only when **all** of the following hold for `tasks/<short-desc>/`:
+Archive fires only when **all** of the following hold for `.oh/tasks/<short-desc>/`:
 
 1. `prd.json` already exists (re-running ralph on a feature that ran before).
 2. `progress.txt` has content beyond the header (the runner has written entries — there is execution history worth preserving).
@@ -272,7 +272,7 @@ Archive fires only when **all** of the following hold for `tasks/<short-desc>/`:
 If both hold:
 
 1. Read the current `prd.json` and `progress.txt`.
-2. Create `tasks/<short-desc>/archive/<ISO-timestamp>/` where the timestamp is `YYYY-MM-DDTHH-MM-SS` (UTC; second-resolution avoids same-day collisions).
+2. Create `.oh/tasks/<short-desc>/archive/<ISO-timestamp>/` where the timestamp is `YYYY-MM-DDTHH-MM-SS` (UTC; second-resolution avoids same-day collisions).
 3. Copy `prd.json` and `progress.txt` into that directory.
 4. Reset `progress.txt` to its header only:
 
@@ -291,8 +291,8 @@ Different `branchName`s do not trigger archiving. In the per-folder layout, a di
 
 Before writing prd.json, verify:
 
-- [ ] Operating on `tasks/<short-desc>/` — folder name is the feature name
-- [ ] **Archive on rerun:** if `prd.json` exists AND `progress.txt` has run history, archived to `tasks/<short-desc>/archive/<ISO-timestamp>/` before overwriting
+- [ ] Operating on `.oh/tasks/<short-desc>/` — folder name is the feature name
+- [ ] **Archive on rerun:** if `prd.json` exists AND `progress.txt` has run history, archived to `.oh/tasks/<short-desc>/archive/<ISO-timestamp>/` before overwriting
 - [ ] Each story is completable in one iteration (small enough)
 - [ ] Stories are ordered by dependency (schema to backend to UI)
 - [ ] Every story has "Typecheck passes" as criterion

--- a/skills/render-html/SKILL.md
+++ b/skills/render-html/SKILL.md
@@ -33,7 +33,7 @@ Common targets in this harness:
 ## When NOT to use
 
 Skip when the artifact is **source or pipeline input** — Markdown stays the substrate of the harness:
-- PRDs (`tasks/*/prd.md`), briefings, commit messages, PR bodies, `CHANGELOG.md`
+- PRDs (`.oh/tasks/*/prd.md`), briefings, commit messages, PR bodies, `CHANGELOG.md`
 - Memory log entries themselves (`memory/<date>/log.md`)
 - Skill/identity sources (`CLAUDE.md`, `context/`, `.claude/skills/`)
 - Agent-to-agent handoffs (advisor → executor briefings)

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -142,7 +142,7 @@ Discard any surviving hypothesis that matches a row in the "What Does NOT Go in 
 | Contains a secret, token, or credential | Memory may be committed |
 | Is raw stdout or command output | Use interpretation, not transcript |
 | Belongs in a commit message or PR body | Duplication causes drift |
-| Is a step-by-step task plan | Plans belong in `tasks/<name>/prd.json` |
+| Is a step-by-step task plan | Plans belong in `.oh/tasks/<name>/prd.json` |
 | Re-derivable in under a minute | Reading one file answers it — don't memorize |
 
 Also discard any hypothesis already captured, verbatim or in substance, in `memory/MEMORY.md` or `context/IDENTITY.md` — link or skip; never double-write. Finally, drop from promotion every hypothesis whose verdict is `refuted` or `inconclusive`, or whose confidence is `low` (these remain in the log only).

--- a/skills/retro/references/memory-protocol.md
+++ b/skills/retro/references/memory-protocol.md
@@ -136,7 +136,7 @@ is not: treat existing entries as immutable once written.
 | Secrets, tokens, credentials | Memory files may be committed; secrets go in environment variables or a vault |
 | Raw stdout / command output | Transient logs belong in `/tmp`; only the interpretation goes in memory |
 | Content destined for commit messages or PR bodies | Those belong in the commit/PR; duplicating here creates drift |
-| Step-by-step task plans | Plans belong in `tasks/<name>/prd.json` or the PRD; memory holds outcomes, not intentions |
+| Step-by-step task plans | Plans belong in `.oh/tasks/<name>/prd.json` or the PRD; memory holds outcomes, not intentions |
 | Anything re-derivable in under a minute | If reading one file answers the question, don't memorize the answer |
 
 ## Boundary with `context/IDENTITY.md`

--- a/skills/ship-spec/SKILL.md
+++ b/skills/ship-spec/SKILL.md
@@ -22,12 +22,12 @@ Compose the existing primitives (`/prd`, wiki synthesis per `.mifune/skills/wiki
 
 ```mermaid
 flowchart TD
-    A["1. Parse args + derive slug"] --> B["2. /prd → tasks/<slug>/prd.md"]
+    A["1. Parse args + derive slug"] --> B["2. /prd → .oh/tasks/<slug>/prd.md"]
     B --> W["2.5 Wiki alignment<br/>compare local spec/wiki against DeepWiki"]
     W --> D["3. Spawn 2 critics in parallel<br/>(implementer + user lens)<br/>cross-check wiki alignment + protected paths"]
     D --> E["4. Resolve critique<br/>HALT if high-severity"]
     E --> C["5. Open GH issue → #N<br/>(only after PROCEED)"]
-    C --> F["6. /ralph → tasks/<slug>/prd.json"]
+    C --> F["6. /ralph → .oh/tasks/<slug>/prd.json"]
     F --> G["7. Scaffold prompt.md + progress.txt"]
     G --> G2["7.5 /compact (before implement)<br/>after PRD artifacts"]
     G2 --> H["8. Branch + commit + push"]
@@ -56,7 +56,7 @@ Extract:
 - **`--repo <owner/name>`** (optional, default `mifunedev/openharness`) — GitHub repository for issue/PR operations.
 - **`--remote <name>`** (optional, default resolved from `--repo`) — git remote to fetch/push work branches.
 - **`--base <branch>`** (optional, default `development`) — PR base and branch start point.
-- **`--executor=ralph|delegate-advisor`** (optional, default `ralph`) — Stage 10 build executor. `ralph` (default): the Advisor monitors `scripts/ralph.sh` directly (the Monitored async loop; `/delegate` is an optional within-iteration fan-out tool, never a replacement for the loop). `delegate-advisor`: the legacy `/delegate --plan tasks/<slug>/prd.json` worker fan-out.
+- **`--executor=ralph|delegate-advisor`** (optional, default `ralph`) — Stage 10 build executor. `ralph` (default): the Advisor monitors `scripts/ralph.sh` directly (the Monitored async loop; `/delegate` is an optional within-iteration fan-out tool, never a replacement for the loop). `delegate-advisor`: the legacy `/delegate --plan .oh/tasks/<slug>/prd.json` worker fan-out.
 
 ```bash
 SHIP_SPEC_REPO="${SHIP_SPEC_REPO:-mifunedev/openharness}"
@@ -86,7 +86,7 @@ Derive `<slug>` per `/prd` rules: lowercase, kebab-case, `[a-z0-9-]+`, **≤5 wo
 
 The slug is the universal key — it's the task directory, tmux session name, second segment of the branch, and embedded in the PR title. Choose once; never re-derive.
 
-### Stage 2 — `/prd` → `tasks/<slug>/prd.md`
+### Stage 2 — `/prd` → `.oh/tasks/<slug>/prd.md`
 
 Invoke the `prd` skill via the Skill tool:
 
@@ -97,11 +97,11 @@ args: <feature-description> + optional plan-file content
 
 If `--plan <path>` was provided, pass the plan content with explicit instruction to skip clarifying questions (the plan answers them). Otherwise allow the skill to ask its standard 3-5 clarifying questions before generating.
 
-Verify output exists at `tasks/<slug>/prd.md` before proceeding.
+Verify output exists at `.oh/tasks/<slug>/prd.md` before proceeding.
 
 ### Stage 2.5 — Wiki alignment + DeepWiki comparison
 
-Before critics run, make the PRD explicit about wiki impact. Read `.mifune/skills/wiki/references/schema.md` and compare the spec's topic against the public DeepWiki for this repository (`https://deepwiki.com/mifunedev/openharness`), opening the most relevant DeepWiki page(s) when the topic maps to an existing subsystem. Record the result in `tasks/<slug>/prd.md` as a `## Wiki Alignment` section:
+Before critics run, make the PRD explicit about wiki impact. Read `.mifune/skills/wiki/references/schema.md` and compare the spec's topic against the public DeepWiki for this repository (`https://deepwiki.com/mifunedev/openharness`), opening the most relevant DeepWiki page(s) when the topic maps to an existing subsystem. Record the result in `.oh/tasks/<slug>/prd.md` as a `## Wiki Alignment` section:
 
 ```markdown
 ## Wiki Alignment
@@ -129,12 +129,12 @@ Both critics receive an additional cross-check instruction: read `.claude/protec
 
 #### Critic A — Implementer's lens
 
-> You are an adversarial implementer reviewing a PRD before any code is written. Read `tasks/<slug>/prd.md`. Read `.claude/protected-paths.txt` and treat its entries as MUST-NOT-DELETE without an override note. Your job: surface technical risks BEFORE implementation begins.
+> You are an adversarial implementer reviewing a PRD before any code is written. Read `.oh/tasks/<slug>/prd.md`. Read `.claude/protected-paths.txt` and treat its entries as MUST-NOT-DELETE without an override note. Your job: surface technical risks BEFORE implementation begins.
 >
 > Focus on:
 > 1. **Vague acceptance criteria** — flag any AC that isn't directly verifiable
 > 2. **Missing dependencies** — what does each story silently assume exists?
-> 3. **Pattern conflicts** — does any story break an existing convention in this repo? Read `AGENTS.md` + the relevant `.mifune/skills/*/SKILL.md` (and any sibling `tasks/*/prd.json`, if present) for established patterns.
+> 3. **Pattern conflicts** — does any story break an existing convention in this repo? Read `AGENTS.md` + the relevant `.mifune/skills/*/SKILL.md` (and any sibling `.oh/tasks/*/prd.json`, if present) for established patterns.
 > 4. **Scope creep within stories** — are any "single iteration" stories actually 2+ stories?
 > 5. **Hidden destructive operations** — does any story imply file deletion / branch deletion / PR closure that isn't explicitly gated?
 > 6. **Wiki alignment** — if the task changes architecture, skill behavior, runtime flow, agent roles, or reusable vocabulary, does `## Wiki Alignment` exist, require the right local wiki updates, and compare against the relevant DeepWiki page(s)? Missing or shallow wiki alignment is SEVERITY: M; mark SEVERITY: H if the PRD would publish contradictory wiki guidance.
@@ -149,7 +149,7 @@ Both critics receive an additional cross-check instruction: read `.claude/protec
 
 #### Critic B — User's lens
 
-> You are an adversarial user reviewing a PRD before implementation. Read `tasks/<slug>/prd.md` and `context/USER.md` (the single-developer / single-project framing). Read `.claude/protected-paths.txt` and treat its entries as MUST-NOT-DELETE without an override note. Your job: surface scope and framing risks BEFORE the team commits.
+> You are an adversarial user reviewing a PRD before implementation. Read `.oh/tasks/<slug>/prd.md` and `context/USER.md` (the single-developer / single-project framing). Read `.claude/protected-paths.txt` and treat its entries as MUST-NOT-DELETE without an override note. Your job: surface scope and framing risks BEFORE the team commits.
 >
 > Focus on:
 > 1. **Scope ambiguity** — what's NOT in the Non-Goals section that should be?
@@ -167,7 +167,7 @@ Both critics receive an additional cross-check instruction: read `.claude/protec
 > ...
 > ```
 
-Write both critics' raw output to `tasks/<slug>/critique.md`:
+Write both critics' raw output to `.oh/tasks/<slug>/critique.md`:
 
 ```markdown
 # Critique — <slug>
@@ -188,7 +188,7 @@ Generated <date>; reviews `prd.md` post-/prd, pre-/ralph.
 
 ### Stage 4 — Resolve critique
 
-Read `tasks/<slug>/critique.md`. Apply the gate:
+Read `.oh/tasks/<slug>/critique.md`. Apply the gate:
 
 | Condition | Action |
 |---|---|
@@ -196,7 +196,7 @@ Read `tasks/<slug>/critique.md`. Apply the gate:
 | Only `SEVERITY: M` or `L` findings | **PROCEED.** Append synthesis paragraph to prd.md noting the medium/low risks were acknowledged; continue to stage 5 |
 | No findings | **PROCEED.** Append "Critics found no issues" line to prd.md; continue |
 
-The HALT path is the whole point. Critics are the short feedback loop; honoring their high-severity findings is what makes this safer than the v0.7 convergence pattern. Note: stages 1-4 produce ONLY local artifacts (prd.md, critique.md). No GitHub-side state exists until stage 5 — meaning a HALT is fully reversible with `rm -rf tasks/<slug>/`.
+The HALT path is the whole point. Critics are the short feedback loop; honoring their high-severity findings is what makes this safer than the v0.7 convergence pattern. Note: stages 1-4 produce ONLY local artifacts (prd.md, critique.md). No GitHub-side state exists until stage 5 — meaning a HALT is fully reversible with `rm -rf .oh/tasks/<slug>/`.
 
 ### Stage 5 — Open GH issue → `#N`
 
@@ -219,7 +219,7 @@ gh issue create \
     "<from prd.md goals>" \
     "" \
     "## PRD" \
-    "- tasks/<slug>/prd.md (this branch)" \
+    "- .oh/tasks/<slug>/prd.md (this branch)" \
     "" \
     "## Wiki Alignment" \
     "- Impact: <REQUIRED | NOT-APPLICABLE from prd.md>" \
@@ -237,16 +237,16 @@ Capture the returned issue URL; extract `<N>` (issue number) for downstream use.
 
 If `gh label create <prefix> --repo "$SHIP_SPEC_REPO"` is needed (label doesn't exist), create it first with a sensible color. Heredoc bodies are safe — the `deny-env-dump.sh` hook strips heredoc bodies before pattern-scanning, so `--body "$(cat <<'EOF' ... EOF)"` is fine.
 
-### Stage 6 — `/ralph` → `tasks/<slug>/prd.json`
+### Stage 6 — `/ralph` → `.oh/tasks/<slug>/prd.json`
 
 Invoke the `ralph` skill:
 
 ```
 Skill: ralph
-args: tasks/<slug>/ --issue <N> --prefix <prefix>
+args: .oh/tasks/<slug>/ --issue <N> --prefix <prefix>
 ```
 
-The skill produces `tasks/<slug>/prd.json` with `branchName: <prefix>/<N>-<slug>`. Verify it exists and parses (use `node -e "require('./tasks/<slug>/prd.json')"`).
+The skill produces `.oh/tasks/<slug>/prd.json` with `branchName: <prefix>/<N>-<slug>`. Verify it exists and parses (use `node -e "require('./.oh/tasks/<slug>/prd.json')"`).
 
 ### Stage 7 — Scaffold `prompt.md` + `progress.txt`
 
@@ -256,7 +256,7 @@ Clone `.claude/skills/ship-spec/templates/prompt.md` as the template (it ships w
 - Replace `#<issue>` with the tracking issue number
 - Confirm the read-context list (step 1) points at this task's prd.md, prd.json, critique.md, progress.txt (the template already references `.mifune/skills/advisor/SKILL.md` for critic-gated stories)
 
-Write `tasks/<slug>/progress.txt` with header only:
+Write `.oh/tasks/<slug>/progress.txt` with header only:
 
 ```
 # progress
@@ -267,7 +267,7 @@ Verify the four-file contract exists:
 
 ```bash
 for f in prd.md prd.json prompt.md progress.txt; do
-  [ -f "tasks/<slug>/$f" ] || { echo "MISSING: $f"; exit 1; }
+  [ -f ".oh/tasks/<slug>/$f" ] || { echo "MISSING: $f"; exit 1; }
 done
 ```
 
@@ -278,7 +278,7 @@ done
 This is the first of two compacts that bracket the implement phase. The PRD artifacts now exist on disk and the heaviest planning context — `/prd` plus the two critics — is already spent. Run `/compact` to reclaim that context before the commit/PR and the implementation handoff. Preserve only the handoff keys:
 
 ```text
-Preserve /ship-spec handoff context: slug <slug>, prefix <prefix>, issue #<N>, branch <prefix>/<N>-<slug>, critique H/M/L counts, four-file contract path tasks/<slug>/. Stages 8–9 re-read prd.md/prd.json/critique.md from disk.
+Preserve /ship-spec handoff context: slug <slug>, prefix <prefix>, issue #<N>, branch <prefix>/<N>-<slug>, critique H/M/L counts, four-file contract path .oh/tasks/<slug>/. Stages 8–9 re-read prd.md/prd.json/critique.md from disk.
 ```
 
 Stages 8–9 re-read the files from disk, so a post-compact context is sufficient. `/compact` is an optimization, not a gate — if it is unavailable or errors, log a warning and continue.
@@ -291,7 +291,7 @@ git fetch "$SHIP_SPEC_REMOTE" "$SHIP_SPEC_BASE"
 git checkout -b "<prefix>/<N>-<slug>" "$SHIP_SPEC_REMOTE/$SHIP_SPEC_BASE" 2>/dev/null \
   || git checkout "<prefix>/<N>-<slug>"
 
-git add "tasks/<slug>/"
+git add ".oh/tasks/<slug>/"
 git commit -m "$(cat <<'EOF'
 <prefix>: scaffold <slug> task
 
@@ -372,7 +372,7 @@ tmux new-session -d -s "$SESSION" -c "${WT:-$PWD}" \
 
 **Advisor `/goal` prompt** (one line; fill the placeholders — when `$CRON_WORKTREE` is set, substitute its actual path for `<worktree>` and use the "reuse" branch of step 1):
 
-> `/goal` As an **expert Advisor on `/worktrees`**, implement `tasks/<slug>/prd.json` for PR `#<PR>` on branch `<prefix>/<N>-<slug>`. (1) **If `<worktree>` is already provided** (autopilot's `$CRON_WORKTREE`, already on branch `<prefix>/<N>-<slug>`): `cd <worktree>` and do NOT create another worktree. **Otherwise** create an isolated worktree at `.worktrees/<prefix>/<N>-<slug>` via `/worktrees` and `cd` into it. (2) **Drive the build per `$SHIP_SPEC_EXECUTOR` (default `ralph`).** *Default (`ralph`)* — the Monitored async loop: launch `scripts/ralph.sh <slug>` in a named tmux session and **own the `STATUS: COMPLETE` watch yourself** (poll `tasks/<slug>/progress.txt` + the loop's tmux liveness; never delegate the watch to a sub-agent that returns early). A ralph iteration **may** call `/delegate` to fan out one story's disjoint files, but `/delegate` does **not** replace the loop. Given multiple **independent** tasks, run one `scripts/ralph.sh` per task in parallel (each its own slug + tmux session) and monitor each to its own `STATUS: COMPLETE`. *Opt-in (`--executor=delegate-advisor`)* — instead orchestrate with `/delegate --plan tasks/<slug>/prd.json`: spawn `general-purpose` worker(s) that each `cd` into that worktree and run `scripts/ralph.sh <slug>`, monitoring `tasks/<slug>/progress.txt` for `STATUS: COMPLETE` and the workers' tmux liveness. (3) Run the `/eval` gate (Stage 11). (4) If `tasks/<slug>/prd.md` has `## Wiki Alignment` with `Impact: REQUIRED`, revise the named `.mifune/skills/wiki/corpus/*.md` entries after implementation so they match the spec's final behavior and acceptance criteria, include DeepWiki-style relevant source files/line citations/system relationships, preserve the recorded DeepWiki comparison, and refresh `.mifune/skills/wiki/corpus/README.md`; verify with `bash evals/probes/wiki-readme-index.sh`. (5) Run `/compact` (Stage 11.5) to clear the implementation context before the audit. (6) In a **separate executor**, run `/pr-audit` for PR `#<PR>` and run `gh pr ready <PR> --repo "$SHIP_SPEC_REPO"` **only if it is classified promotable** (CI green + mergeable + clean); otherwise `gh pr comment` the blocking gate and leave it draft. Never `gh pr merge`. Leave this tmux session alive for attach.
+> `/goal` As an **expert Advisor on `/worktrees`**, implement `.oh/tasks/<slug>/prd.json` for PR `#<PR>` on branch `<prefix>/<N>-<slug>`. (1) **If `<worktree>` is already provided** (autopilot's `$CRON_WORKTREE`, already on branch `<prefix>/<N>-<slug>`): `cd <worktree>` and do NOT create another worktree. **Otherwise** create an isolated worktree at `.worktrees/<prefix>/<N>-<slug>` via `/worktrees` and `cd` into it. (2) **Drive the build per `$SHIP_SPEC_EXECUTOR` (default `ralph`).** *Default (`ralph`)* — the Monitored async loop: launch `scripts/ralph.sh <slug>` in a named tmux session and **own the `STATUS: COMPLETE` watch yourself** (poll `.oh/tasks/<slug>/progress.txt` + the loop's tmux liveness; never delegate the watch to a sub-agent that returns early). A ralph iteration **may** call `/delegate` to fan out one story's disjoint files, but `/delegate` does **not** replace the loop. Given multiple **independent** tasks, run one `scripts/ralph.sh` per task in parallel (each its own slug + tmux session) and monitor each to its own `STATUS: COMPLETE`. *Opt-in (`--executor=delegate-advisor`)* — instead orchestrate with `/delegate --plan .oh/tasks/<slug>/prd.json`: spawn `general-purpose` worker(s) that each `cd` into that worktree and run `scripts/ralph.sh <slug>`, monitoring `.oh/tasks/<slug>/progress.txt` for `STATUS: COMPLETE` and the workers' tmux liveness. (3) Run the `/eval` gate (Stage 11). (4) If `.oh/tasks/<slug>/prd.md` has `## Wiki Alignment` with `Impact: REQUIRED`, revise the named `.mifune/skills/wiki/corpus/*.md` entries after implementation so they match the spec's final behavior and acceptance criteria, include DeepWiki-style relevant source files/line citations/system relationships, preserve the recorded DeepWiki comparison, and refresh `.mifune/skills/wiki/corpus/README.md`; verify with `bash evals/probes/wiki-readme-index.sh`. (5) Run `/compact` (Stage 11.5) to clear the implementation context before the audit. (6) In a **separate executor**, run `/pr-audit` for PR `#<PR>` and run `gh pr ready <PR> --repo "$SHIP_SPEC_REPO"` **only if it is classified promotable** (CI green + mergeable + clean); otherwise `gh pr comment` the blocking gate and leave it draft. Never `gh pr merge`. Leave this tmux session alive for attach.
 
 The Advisor owns Stages 11–13 inside its session. The orchestrator's turn ends after launching it and reporting the session name; the ready-for-review PR is produced asynchronously by the Advisor. Each worker commits the implementation on `<prefix>/<N>-<slug>` with a `Submitted-by:` trailer (per `templates/prompt.md`); worktree isolation keeps concurrent work off the shared checkout (avoiding the autopilot shared-checkout contamination class). If `tmux` is unavailable, fall back to running the executor inline (`scripts/ralph.sh <slug>`) and continue to Stage 11 in the foreground. Stage 13 still requires a fresh Stage 12 `/pr-audit` immediately before `gh pr ready`; stale-draft watchdog/heartbeat output cannot substitute for that audit.
 
@@ -382,7 +382,7 @@ Run `/eval` (the Advisor runs this inside its session) while still on the work b
 
 ### Stage 11.25 — Wiki revision gate
 
-If `tasks/<slug>/prd.md` has `## Wiki Alignment` with `Impact: REQUIRED`, the Advisor must revise the named `.mifune/skills/wiki/corpus/*.md` entries after implementation and before `/pr-audit`. The revision must align with:
+If `.oh/tasks/<slug>/prd.md` has `## Wiki Alignment` with `Impact: REQUIRED`, the Advisor must revise the named `.mifune/skills/wiki/corpus/*.md` entries after implementation and before `/pr-audit`. The revision must align with:
 - the PRD's goals, non-goals, acceptance criteria, and completed behavior;
 - the DeepWiki comparison captured in Stage 2.5;
 - `.mifune/skills/wiki/references/schema.md`'s DeepWiki-style standard: relevant source files, line-cited claims, system relationships for pipelines/runtime/architecture topics, and `## See Also` navigation.
@@ -453,12 +453,12 @@ Every stage checks for prior state and resumes rather than duplicating:
 
 | Stage | Resume check | Behavior |
 |---|---|---|
-| 2 | `tasks/<slug>/prd.md` exists | `/prd` runs in update mode (existing skill behavior) |
+| 2 | `.oh/tasks/<slug>/prd.md` exists | `/prd` runs in update mode (existing skill behavior) |
 | 2.5 | `## Wiki Alignment` exists and still matches the PRD goals/stories | Reuse; otherwise update the section before critics |
-| 3 | `tasks/<slug>/critique.md` exists and is recent (<24h) AND prd.md unchanged since | Skip; reuse |
+| 3 | `.oh/tasks/<slug>/critique.md` exists and is recent (<24h) AND prd.md unchanged since | Skip; reuse |
 | 4 | (no resume — pure decision step) | Re-evaluate critique.md every run |
 | 5 | `--issue <N>` provided, or issue with matching title/label exists | If `--issue <N>`: skip creation, reuse `<N>`. Else reuse the matching issue; never create a duplicate |
-| 6 | `tasks/<slug>/prd.json` exists | `/ralph` archives prior + regenerates (existing skill behavior) |
+| 6 | `.oh/tasks/<slug>/prd.json` exists | `/ralph` archives prior + regenerates (existing skill behavior) |
 | 7 | `prompt.md` / `progress.txt` exist | Skip if present |
 | 7.5 | (no resume — context optimization) | Always safe to run; skip silently if `/compact` is unavailable |
 | 8 | Branch exists on target remote | Checkout + commit on top |

--- a/skills/ship-spec/templates/prompt.md
+++ b/skills/ship-spec/templates/prompt.md
@@ -1,6 +1,6 @@
 # Ralph iteration — <slug>
 
-You are one iteration of a Ralph loop implementing the `<slug>` task. The full plan is in `tasks/<slug>/prd.md` and the structured task list is in `tasks/<slug>/prd.json`. The loop calls you again until `progress.txt` contains a line `STATUS: COMPLETE`.
+You are one iteration of a Ralph loop implementing the `<slug>` task. The full plan is in `.oh/tasks/<slug>/prd.md` and the structured task list is in `.oh/tasks/<slug>/prd.json`. The loop calls you again until `progress.txt` contains a line `STATUS: COMPLETE`.
 
 ## Execution model
 
@@ -18,10 +18,10 @@ Pick **one** user story, implement it, commit, mark it `passes: true`, and appen
 ## Steps every iteration
 
 1. **Read context** — in this order:
-   - `tasks/<slug>/prd.json` — find the lowest-`priority` story where `passes: false`. That is your story for this iteration.
-   - `tasks/<slug>/progress.txt` — read the "Codebase Patterns" section at the top (if any) and the most recent few iterations to see what's been done.
-   - `tasks/<slug>/critique.md` — if present, the critic findings the stories must satisfy.
-   - If `tasks/<slug>/prd.md` contains `## Wiki Alignment`, read it before choosing the story. When `Impact: REQUIRED`, the relevant story must keep wiki updates aligned with the PRD and the recorded DeepWiki comparison.
+   - `.oh/tasks/<slug>/prd.json` — find the lowest-`priority` story where `passes: false`. That is your story for this iteration.
+   - `.oh/tasks/<slug>/progress.txt` — read the "Codebase Patterns" section at the top (if any) and the most recent few iterations to see what's been done.
+   - `.oh/tasks/<slug>/critique.md` — if present, the critic findings the stories must satisfy.
+   - If `.oh/tasks/<slug>/prd.md` contains `## Wiki Alignment`, read it before choosing the story. When `Impact: REQUIRED`, the relevant story must keep wiki updates aligned with the PRD and the recorded DeepWiki comparison.
    - `.mifune/skills/wiki/references/schema.md` when your story touches `.mifune/skills/wiki/corpus/` or the PRD's Wiki Alignment section says `Impact: REQUIRED`.
    - `.claude/skills/git/SKILL.md` for branch + commit conventions.
    - `.mifune/skills/t3/references/sandbox-processes.md` for tmux session conventions if your story spawns processes.
@@ -109,7 +109,7 @@ If the chosen story cannot be completed this iteration:
 
 ## Reference
 
-- PRD: `tasks/<slug>/prd.md`
-- Structured stories: `tasks/<slug>/prd.json`
+- PRD: `.oh/tasks/<slug>/prd.md`
+- Structured stories: `.oh/tasks/<slug>/prd.json`
 - Branch: `<prefix>/<N>-<slug>`
 - Issue: #<issue>

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -3,14 +3,14 @@ name: spec
 description: >-
   Dispatcher for the canonical decomposed workflow (AGENTS.md § The Workflow) —
   routes the first token of $ARGUMENTS to one of four subcommands: plan, critique,
-  execute, or retro. Each is pointed at a tasks/<slug>/ folder (the universal
+  execute, or retro. Each is pointed at a .oh/tasks/<slug>/ folder (the universal
   interface) and is the same independently-runnable, fan-out-able node /ship-spec
   decomposes into. Full per-subcommand procedures live in
   references/{plan,critique,execute,retro}.md. Authority: AGENTS.md § The Workflow.
   TRIGGER when: a topic/plan/issue needs to become a buildable task folder, "plan
-  <topic>", "scaffold the task for <issue>" -> plan; a planned tasks/<slug>/ folder
+  <topic>", "scaffold the task for <issue>" -> plan; a planned .oh/tasks/<slug>/ folder
   needs adversarial review + a go/no-go decision, "critique <slug>", "vet the plan
-  for <slug>" -> critique; an APPROVED tasks/<slug>/ folder needs building to a
+  for <slug>" -> critique; an APPROVED .oh/tasks/<slug>/ folder needs building to a
   promotable PR, "execute <slug>", "build <slug>" -> execute; a build PASSed audit
   and its lessons should be captured, "retro the <slug> build", "capture lessons
   for <slug>" -> retro.
@@ -35,10 +35,10 @@ split so each node can be run independently or fanned out at scale via `/delegat
 
 | Subcommand | Arg shape | Purpose | Procedure |
 |---|---|---|---|
-| `plan` | `<topic> [--plan <path>] [--issue <N>] [--slug <slug>] [--prefix <type>] [--repo <o/n>] [--base <branch>]` | Turn a topic/plan/issue into a fully-scaffolded `tasks/<slug>/` four-file folder | `references/plan.md` |
+| `plan` | `<topic> [--plan <path>] [--issue <N>] [--slug <slug>] [--prefix <type>] [--repo <o/n>] [--base <branch>]` | Turn a topic/plan/issue into a fully-scaffolded `.oh/tasks/<slug>/` four-file folder | `references/plan.md` |
 | `critique` | `<slug> [--auto]` | Run the two adversarial critics (`/critique`) + the commitment gate (`/approve`); the `plan ⇄ critique` loop | `references/critique.md` |
 | `execute` | `<slug> [--pr <N>] [--repo <o/n>] [--remote <name>] [--base <branch>]` | `build ⇄ audit → spec-retro → improve → groom` to a ready PR, stopping at the human merge gate | `references/execute.md` |
-| `retro` | `<slug> [--dry-run]` | Execution-side `/retro` scoped to a built `tasks/<slug>/` | `references/retro.md` |
+| `retro` | `<slug> [--dry-run]` | Execution-side `/retro` scoped to a built `.oh/tasks/<slug>/` | `references/retro.md` |
 
 ## Dispatch
 
@@ -67,7 +67,7 @@ esac
   (`select → spec-plan ⇄ spec-critique → spec-execute → merge → reset|clean`),
   the single designated runner (`/autopilot`), and the `/ship-spec` caveat all
   live there. Defer to it; do not redefine the workflow here.
-- **The `tasks/<slug>/` folder is the universal interface** — `plan` produces it;
+- **The `.oh/tasks/<slug>/` folder is the universal interface** — `plan` produces it;
   `critique`, `execute`, and `retro` are each pointed at it. The `<slug>` is the
   universal key (task directory, branch second segment, tmux session name).
 - **Compose, don't fork** — each node reuses existing loop-node skills rather than

--- a/skills/spec/references/critique.md
+++ b/skills/spec/references/critique.md
@@ -7,11 +7,11 @@
 
 The **critique** node of the `spec-*` family (`AGENTS.md § The Workflow`). It is the
 first of the two adversarial loops — `spec-plan ⇄ spec-critique` vets the *plan*
-(`build ⇄ audit` later vets the *build*). Pointed at a `tasks/<slug>/` folder, it runs
+(`build ⇄ audit` later vets the *build*). Pointed at a `.oh/tasks/<slug>/` folder, it runs
 the critics and the gate, then hands off.
 
 **Core principle: gate the spec while it is still the cheapest thing to revise.** Critics
-review `tasks/<slug>/prd.md` and the gate decides **before** any GitHub-side state exists
+review `.oh/tasks/<slug>/prd.md` and the gate decides **before** any GitHub-side state exists
 (`AGENTS.md § The Workflow` critic-before-commitment invariant). A `DENIED` is fully
 reversible — it routes back to `/spec plan` to revise the PRD and re-critique; nothing
 GitHub-side is created until `APPROVED`.
@@ -20,7 +20,7 @@ This composes two existing loop-node skills — it does **not** re-implement the
 
 | Step | Skill | Produces |
 |------|-------|----------|
-| 1. critics | `/critique <slug>` | `tasks/<slug>/critique.md` (2 critics, implementer + user lens, SEVERITY-tagged + protected-paths cross-check) |
+| 1. critics | `/critique <slug>` | `.oh/tasks/<slug>/critique.md` (2 critics, implementer + user lens, SEVERITY-tagged + protected-paths cross-check) |
 | 2. gate | `/approve <slug> [--auto]` | the `APPROVED` / `DENIED` verdict over that `critique.md` |
 
 It is the decomposed, folder-pointed form of `/ship-spec` Stages 3–4.
@@ -31,10 +31,10 @@ It is the decomposed, folder-pointed form of `/ship-spec` Stages 3–4.
 
 | Arg | Meaning |
 |-----|---------|
-| `<slug>` | The task slug — locates `tasks/<slug>/prd.md`; critics write `tasks/<slug>/critique.md`. Required. |
+| `<slug>` | The task slug — locates `.oh/tasks/<slug>/prd.md`; critics write `.oh/tasks/<slug>/critique.md`. Required. |
 | `--auto` | Unattended mode (passed through to `/approve`): the SEVERITY auto-gate alone decides; never prompt a human. |
 
-If `tasks/<slug>/prd.md` is absent there is nothing to critique — print an error pointing
+If `.oh/tasks/<slug>/prd.md` is absent there is nothing to critique — print an error pointing
 at `/spec plan` and emit no `STATUS:` line (a missing spec is a failure, not a clean pass).
 
 ---
@@ -43,7 +43,7 @@ at `/spec plan` and emit no `STATUS:` line (a missing spec is a failure, not a c
 
 1. **Critics** — invoke `/critique <slug>`. It launches the two `critic` agents in
    parallel (different lenses; both cross-check `.claude/protected-paths.txt`) and writes
-   `tasks/<slug>/critique.md` with the SEVERITY tally and a `Recommendation`. Do not run
+   `.oh/tasks/<slug>/critique.md` with the SEVERITY tally and a `Recommendation`. Do not run
    the critics inline here — delegate to `/critique` so the single authoring of that
    prompt is reused.
 
@@ -54,7 +54,7 @@ at `/spec plan` and emit no `STATUS:` line (a missing spec is a failure, not a c
 
 3. **Route**:
    - `APPROVED` → the spec clears the gate; hand off to `/spec execute <slug>`.
-   - `DENIED` → name the blocking finding(s), point at `tasks/<slug>/critique.md`, and hand
+   - `DENIED` → name the blocking finding(s), point at `.oh/tasks/<slug>/critique.md`, and hand
      back to `/spec plan <slug>` to revise the PRD and re-run this node. The revision is
      local-only — nothing GitHub-side exists yet.
 

--- a/skills/spec/references/execute.md
+++ b/skills/spec/references/execute.md
@@ -7,7 +7,7 @@
 > `$ARGUMENTS`. Authority: `AGENTS.md § The Workflow`.
 
 The **execute** node of the `spec-*` family (`AGENTS.md § The Workflow`). Pointed at an
-**APPROVED** `tasks/<slug>/` folder (cleared by `/spec critique`), it drives the build to
+**APPROVED** `.oh/tasks/<slug>/` folder (cleared by `/spec critique`), it drives the build to
 a ready-for-review PR and stops at the human merge gate. It contains the second adversarial
 loop — `build ⇄ audit` — mirroring the `spec-plan ⇄ spec-critique` loop that vetted the plan.
 
@@ -30,13 +30,13 @@ runnable on its own folder or fanned out at scale via `/delegate`.
 
 | Arg | Meaning |
 |-----|---------|
-| `<slug>` | The task slug — reads the four-file contract in `tasks/<slug>/` and `prd.json`'s `branchName`. Required. |
+| `<slug>` | The task slug — reads the four-file contract in `.oh/tasks/<slug>/` and `prd.json`'s `branchName`. Required. |
 | `--pr <N>` | Resume against an existing PR rather than creating one. |
 | `--repo <owner/name>` | GitHub repo (default `mifunedev/openharness`; read from the folder if `/spec plan` recorded it). |
 | `--remote <name>` | Git remote (resolved from `--repo` if absent). |
 | `--base <branch>` | PR base + branch start point (default `development`). |
 
-Precondition: `/spec critique <slug>` returned `SPEC-APPROVED`. If `tasks/<slug>/` is not
+Precondition: `/spec critique <slug>` returned `SPEC-APPROVED`. If `.oh/tasks/<slug>/` is not
 APPROVED (no `critique.md`, or its verdict is `DENIED`), refuse and route back to
 `/spec critique` — do not build an ungated spec (`AGENTS.md § The Workflow`
 critic-before-commitment invariant).
@@ -56,7 +56,7 @@ specifies — an expert `/worktrees` Advisor in a tmux session (`agent-ship-<slu
 `/goal` that, by default (`--executor=ralph`), **monitors `scripts/ralph.sh <slug>` directly**
 in an isolated worktree to `STATUS: COMPLETE` (`/delegate` is an optional within-iteration
 fan-out tool, never a replacement for the loop; `--executor=delegate-advisor` selects the
-legacy `/delegate --plan tasks/<slug>/prd.json` worker fan-out). Use that skill's stage text
+legacy `/delegate --plan .oh/tasks/<slug>/prd.json` worker fan-out). Use that skill's stage text
 as the authority for the mechanics; do not duplicate them here.
 
 ### 2. `build ⇄ audit` — the second adversarial loop

--- a/skills/spec/references/plan.md
+++ b/skills/spec/references/plan.md
@@ -1,4 +1,4 @@
-# `/spec plan` — produce the `tasks/<slug>/` folder
+# `/spec plan` — produce the `.oh/tasks/<slug>/` folder
 
 > Detail doc for the **`plan`** subcommand of the `/spec` skill
 > (`.mifune/skills/spec/SKILL.md`). Argument form:
@@ -8,12 +8,12 @@
 
 The **plan** node of the `spec-*` family (`AGENTS.md § The Workflow`:
 `select → spec-plan ⇄ spec-critique → spec-execute → merge → reset|clean`). It takes
-a topic / plan file / issue and produces the **`tasks/<slug>/` folder** — the universal
+a topic / plan file / issue and produces the **`.oh/tasks/<slug>/` folder** — the universal
 interface every other `/spec` node is pointed at.
 
 **Core principle: plan cheaply, commit nothing.** `plan` writes only local files
-under `tasks/<slug>/`. It runs no critics and creates no GitHub-side state — that keeps
-the plan ⇄ critique loop fully reversible (`rm -rf tasks/<slug>/`) until `/spec critique`
+under `.oh/tasks/<slug>/`. It runs no critics and creates no GitHub-side state — that keeps
+the plan ⇄ critique loop fully reversible (`rm -rf .oh/tasks/<slug>/`) until `/spec critique`
 clears it (`AGENTS.md § The Workflow` invariant: critic-before-commitment).
 
 This is the decomposed form of `/ship-spec` Stages 1–2.5, 6–7. `/ship-spec` remains the
@@ -49,9 +49,9 @@ Run these in order; each is an existing primitive — compose, don't re-derive.
    second segment, tmux session name. Choose once; reject and ask for a shorter name if
    invalid. `--slug` overrides derivation.
 
-2. **`/prd` → `tasks/<slug>/prd.md`** (Stage 2). Invoke the `prd` skill with `<topic>`
+2. **`/prd` → `.oh/tasks/<slug>/prd.md`** (Stage 2). Invoke the `prd` skill with `<topic>`
    (or `--plan` content, with an explicit instruction to skip clarifying questions when a
-   plan is supplied). Verify `tasks/<slug>/prd.md` exists before continuing.
+   plan is supplied). Verify `.oh/tasks/<slug>/prd.md` exists before continuing.
 
 3. **Wiki alignment** (Stage 2.5). Read `.mifune/skills/wiki/references/schema.md`, compare the topic against
    the public DeepWiki for this repo, and record a `## Wiki Alignment` section in
@@ -60,24 +60,24 @@ Run these in order; each is an existing primitive — compose, don't re-derive.
    exact shape is `/ship-spec` Stage 2.5; reuse it verbatim so `/spec execute`'s wiki gate
    can read it.
 
-4. **`/ralph` → `tasks/<slug>/prd.json`** (Stage 6). Invoke the `ralph` skill:
-   `tasks/<slug>/ --issue <N> --prefix <prefix>`. It writes `prd.json` with
+4. **`/ralph` → `.oh/tasks/<slug>/prd.json`** (Stage 6). Invoke the `ralph` skill:
+   `.oh/tasks/<slug>/ --issue <N> --prefix <prefix>`. It writes `prd.json` with
    `branchName: <prefix>/<N>-<slug>`. Verify it parses
-   (`node -e "require('./tasks/<slug>/prd.json')"`). **`/ralph` hard-fails without
+   (`node -e "require('./.oh/tasks/<slug>/prd.json')"`). **`/ralph` hard-fails without
    `--issue <N>`** (the branch name embeds it) — in the canonical flow `<N>` is the issue
    `/autopilot` selected; for a fresh manual topic with no issue, open one first per `/git`
    or use `/ship-spec`. `plan` consumes the number; it never creates the issue.
 
 5. **Scaffold `prompt.md` + `progress.txt`** (Stage 7). Clone
    `.claude/skills/ship-spec/templates/prompt.md`, substituting `<slug>`,
-   `<prefix>/<N>-<slug>`, and `#<issue>`. Write `tasks/<slug>/progress.txt` with the
+   `<prefix>/<N>-<slug>`, and `#<issue>`. Write `.oh/tasks/<slug>/progress.txt` with the
    `# progress` header only.
 
 Verify the four-file contract before handing off:
 
 ```bash
 for f in prd.md prd.json prompt.md progress.txt; do
-  [ -f "tasks/<slug>/$f" ] || { echo "MISSING: $f"; exit 1; }
+  [ -f ".oh/tasks/<slug>/$f" ] || { echo "MISSING: $f"; exit 1; }
 done
 ```
 
@@ -85,7 +85,7 @@ done
 
 ## Output
 
-`tasks/<slug>/` holding the four-file contract (`prd.md`, `prd.json`, `prompt.md`,
+`.oh/tasks/<slug>/` holding the four-file contract (`prd.md`, `prd.json`, `prompt.md`,
 `progress.txt`). No `critique.md` yet (that is `/spec critique`). No issue, branch, or PR.
 
 ---

--- a/skills/spec/references/retro.md
+++ b/skills/spec/references/retro.md
@@ -14,7 +14,7 @@ lessons.
 scientific session-closing pass — falsifiable hypotheses, evidence for *and* against, a
 verdict + confidence, and a propose-then-confirm promotion into `memory/MEMORY.md` /
 `context/IDENTITY.md`. `retro` is the execution-side application of it: point `/retro`
-at the just-built `tasks/<slug>/` run so the reflection is anchored to that unit's
+at the just-built `.oh/tasks/<slug>/` run so the reflection is anchored to that unit's
 artifacts (`prd.md`, `progress.txt`, `prd.json`, `critique.md`, the `/audit` evidence)
 rather than the whole ambient session.
 
@@ -28,10 +28,10 @@ records that the execution stage ran its retro.
 
 | Arg | Meaning |
 |-----|---------|
-| `<slug>` | The task slug — the retro reads `tasks/<slug>/` artifacts as its primary signal source. Required. |
+| `<slug>` | The task slug — the retro reads `.oh/tasks/<slug>/` artifacts as its primary signal source. Required. |
 | `--dry-run` | Passed through to `/retro`: write only the log entry (`Result: DRY-RUN`); never write `MEMORY.md`/`IDENTITY.md`. |
 
-If `tasks/<slug>/` has no `progress.txt`/`prd.md`, there is no build to reflect on — say so
+If `.oh/tasks/<slug>/` has no `progress.txt`/`prd.md`, there is no build to reflect on — say so
 and fall back to a plain `/retro` on the session, or skip with a logged note.
 
 ---

--- a/skills/sync/references/publish.md
+++ b/skills/sync/references/publish.md
@@ -67,8 +67,8 @@ upstream/development baseline. The goal: `git diff upstream/development HEAD
 # may require translating these paths to .claude/skills/.
 #
 # Private task artifacts — keep only README
-git checkout upstream/development -- tasks/
-git rm -r --cached --ignore-unmatch tasks/*/  # remove sub-dirs if any leaked
+git checkout upstream/development -- .oh/tasks/
+git rm -r --cached --ignore-unmatch .oh/tasks/*/  # remove sub-dirs if any leaked
 # Research wiki corpus — keep README anchors only
 git checkout upstream/development -- .mifune/skills/wiki/corpus/ 2>/dev/null || \
   git checkout upstream/development -- .claude/skills/wiki/corpus/ 2>/dev/null || true
@@ -78,7 +78,7 @@ git checkout upstream/development -- context/IDENTITY.md
 git checkout upstream/development -- context/SOUL.md
 git checkout upstream/development -- context/USER.md
 git checkout upstream/development -- context/TOOLS.md
-# Agent folders (docs/agents/, tasks/archive/) if present
+# Agent folders (docs/agents/, .oh/tasks/archive/) if present
 git checkout upstream/development -- docs/agents/ 2>/dev/null || true
 # Daily memory logs (gitignored locally, but check)
 git checkout upstream/development -- memory/ 2>/dev/null || true
@@ -88,7 +88,7 @@ git checkout upstream/development -- .codex/plans/ 2>/dev/null || true
 
 Verify each sanitized path is clean:
 ```bash
-git diff upstream/development HEAD -- tasks/ memory/ context/ .codex/plans/
+git diff upstream/development HEAD -- .oh/tasks/ memory/ context/ .codex/plans/
 ```
 Output must be empty. If not, inspect the diff and reset the leaking paths.
 

--- a/skills/teach/SKILL.md
+++ b/skills/teach/SKILL.md
@@ -38,7 +38,7 @@ It is **not** an implementation, audit, retro, or merge gate. `/teach` does not 
 Arguments received: `$ARGUMENTS`
 
 Identify:
-- **Task slug or branch** — prefer `tasks/<slug>/` when present. If a branch is given, derive the slug from its trailing segment only after checking for an exact `tasks/<slug>/` match.
+- **Task slug or branch** — prefer `.oh/tasks/<slug>/` when present. If a branch is given, derive the slug from its trailing segment only after checking for an exact `.oh/tasks/<slug>/` match.
 - **Relevant wiki slug** — use `--wiki <slug>` if provided. Otherwise search likely wiki entries by task terms and by changed conceptual surface. If no relevant entry exists, say so and propose the one entry that should be created via `/wiki ingest` or manual wiki authoring; do not fabricate a source-backed entry.
 - **Mode** — `--dry-run` reports the proposed wiki changes and teaching output without writing.
 
@@ -46,10 +46,10 @@ Identify:
 
 Read the task artifacts first:
 
-1. `tasks/<slug>/prd.md` — intended goals, non-goals, and acceptance criteria.
-2. `tasks/<slug>/progress.txt` — implementation chronology, files changed, commits, and Codebase Patterns.
-3. `tasks/<slug>/prd.json` — story pass state and branch name when present.
-4. `tasks/<slug>/critique.md` — critic findings and mitigations when present.
+1. `.oh/tasks/<slug>/prd.md` — intended goals, non-goals, and acceptance criteria.
+2. `.oh/tasks/<slug>/progress.txt` — implementation chronology, files changed, commits, and Codebase Patterns.
+3. `.oh/tasks/<slug>/prd.json` — story pass state and branch name when present.
+4. `.oh/tasks/<slug>/critique.md` — critic findings and mitigations when present.
 5. Eval/audit/verification evidence when present: `evals/RESULTS.md`, targeted probe output in `progress.txt`, `/audit` or `/pr-audit` notes, CI status, and commit/PR evidence.
 6. The relevant wiki entry (`.mifune/skills/wiki/corpus/<wiki-slug>.md`) before drafting the teaching response.
 


### PR DESCRIPTION
## What

Repoint all instructional references to the workflow task workdir from `tasks/<slug>/` to `.oh/tasks/<slug>/` across skills and agents (23 files).

## Why

Open Harness relocated the Ralph/spec task workdirs from repo-root `tasks/` to `.oh/tasks/` (reclassified from "live identity/state" to `.oh/` machinery, per the RFC #531 governing principle). A back-compat root symlink keeps *filesystem reads* working, but git index operations cannot traverse it — so all references are repointed to the real path.

## Scope

- `agents/auditor.md` + 22 skill docs (`approve`, `audit`, `autopilot`, `caveman-compress`, `critique`, `eval`, `harness-context`, `imagine`, `prd`, `ralph`, `render-html`, `retro` (+ memory-protocol), `ship-spec` (+ template), `spec` (+ 4 references), `sync/publish`, `teach`).
- Excluded `skills/wiki/corpus/**` (immutable external snapshots).
- `SPEC §tasks/` section citations left verbatim (they cite a spec section title, not a path).

## Coupling

The Open Harness companion PR bumps the `.mifune` gitlink to this commit and updates eval probes (`spec-family-contract`, `prd-output-path-contract`) whose literals couple to these skill docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)