### PR TITLE
task: repoint memory/ refs to .oh/memory/

### DIFF
--- a/agents/agent-builder.md
+++ b/agents/agent-builder.md
@@ -246,8 +246,8 @@ initialPrompt: "..."         # Optional: auto-submitted first user turn when run
    - Hard cap on agentic turns before the subagent is forcibly stopped — useful for bounded-cost research/cleanup tasks
 
 10. **memory** (persistent agent memory):
-    - `user` → `~/.claude/agent-memory/<agent-name>/` (cross-project)
-    - `project` → `.claude/agent-memory/<agent-name>/` (project-shared, version-controlled)
+    - `user` → `~/.claude/agent-.oh/memory/<agent-name>/` (cross-project)
+    - `project` → `.claude/agent-.oh/memory/<agent-name>/` (project-shared, version-controlled)
     - `local` → `.claude/agent-memory-local/<agent-name>/` (project-private, gitignore)
     - When set, Read/Write/Edit are auto-enabled and the first 200 lines / 25 KB of `MEMORY.md` are injected. Tell the agent in its prompt to consult and update memory.
 

--- a/agents/agent-builder.md
+++ b/agents/agent-builder.md
@@ -246,8 +246,8 @@ initialPrompt: "..."         # Optional: auto-submitted first user turn when run
    - Hard cap on agentic turns before the subagent is forcibly stopped — useful for bounded-cost research/cleanup tasks
 
 10. **memory** (persistent agent memory):
-    - `user` → `~/.claude/agent-.oh/memory/<agent-name>/` (cross-project)
-    - `project` → `.claude/agent-.oh/memory/<agent-name>/` (project-shared, version-controlled)
+    - `user` → `~/.claude/agent-memory/<agent-name>/` (cross-project)
+    - `project` → `.claude/agent-memory/<agent-name>/` (project-shared, version-controlled)
     - `local` → `.claude/agent-memory-local/<agent-name>/` (project-private, gitignore)
     - When set, Read/Write/Edit are auto-enabled and the first 200 lines / 25 KB of `MEMORY.md` are injected. Tell the agent in its prompt to consult and update memory.
 

--- a/skills/approve/SKILL.md
+++ b/skills/approve/SKILL.md
@@ -114,7 +114,7 @@ GitHub-side exists yet.
 
 ## Memory Protocol
 
-After a run, append to `memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
+After a run, append to `.oh/memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
 
 ```markdown
 ## approve -- HH:MM UTC

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -142,7 +142,7 @@ red from gate 2.
 
 ## Memory Protocol
 
-After a run, append to `memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
+After a run, append to `.oh/memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
 
 ```markdown
 ## audit -- HH:MM UTC

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -128,10 +128,10 @@ log_liveness() { mkdir -p "$AUTOPILOT_LOG_ROOT/crons"; printf '[%s] autopilot: %
 # SH_WORD_SPLIT by default) — either way the clean check matches nothing and is
 # vacuously satisfied. The array form "${OWNED_PATHS[@]}" expands correctly in both.
 # Write-surface cross-check (known-complete): every tracked path autopilot writes in
-# §2–§7 is within OWNED_PATHS — tasks/, evals/, memory/, CHANGELOG.md, and .claude/ are
+# §2–§7 is within OWNED_PATHS — tasks/, evals/, .oh/memory/, CHANGELOG.md, and .claude/ are
 # the autopilot-written tracked dirs, all in the set — else it is committed by the
 # selected executor on the feature branch or lives under /tmp. No autopilot write lands outside this surface.
-OWNED_PATHS=(.claude/ context/ docs/ scripts/ crons/ .mifune/skills/wiki/ evals/ memory/ tasks/ CHANGELOG.md)
+OWNED_PATHS=(.claude/ context/ docs/ scripts/ crons/ .mifune/skills/wiki/ evals/ .oh/memory/ tasks/ CHANGELOG.md)
 
 # Isolated worktree mode (worktree:true cron — the DEFAULT for autopilot): the cron
 # runtime fired this run inside a fresh detached worktree ($CRON_WORKTREE) cut from the
@@ -349,7 +349,7 @@ Pass a 5-field advisor-model briefing:
 - A one-sentence feature description suitable for /ship-spec (≤ ~120 chars).
 - A bullet-list implementation plan (3–7 items).
 
-**Start here**: the ticket body (`gh issue view $ISSUE_NUM --repo $AUTOPILOT_REPO`), memory/MEMORY.md (recent context).
+**Start here**: the ticket body (`gh issue view $ISSUE_NUM --repo $AUTOPILOT_REPO`), .oh/memory/MEMORY.md (recent context).
 
 **Out of scope**: PRD JSON generation, branch creation, git operations.
 ```
@@ -513,7 +513,7 @@ git push "$AUTOPILOT_REMOTE" HEAD
 
 **Release the overlap lock before restoring** (mandatory for kept Pi sessions): after any terminal PR state (`PR-READY`, `PR-DRAFT-CI-RED`, or `PR-DRAFT-EVAL-RED`), run `release_overlap_lock` before the restore. Kept Pi sessions intentionally stay alive for manual review, so the cron wrapper may not regain control to remove `/tmp/cron-autopilot.pid`; the skill must clear `$CRON_OVERLAP_PIDFILE` itself once the run is terminal. Incomplete executor paths (`DELEGATE-FAIL`, `RALPH-INCOMPLETE`) keep the lock because manual continuation is expected.
 
-**Restore branch** (root mode only — when `$CRON_WORKTREE` is set the whole restore is skipped: a worktree run never touched root and its worktree is discarded by the runtime/heartbeat, so there is nothing to restore. In root mode it is mandatory — the next cron fire's §1 branch guard only passes on `development`). Canonical **scoped restore** — a non-destructive two-step that discards only this run's own OWNED-path residue, then switches HEAD. Committed work is safe on the branch / draft PR. The scope step MUST precede the branch switch (it clears owned residue that would otherwise make a non-forced `git checkout development` refuse). It touches only **tracked** files, so an untracked owned-path orphan from a mid-run crash is NOT auto-removed (`git clean` is deliberately NOT used — too destructive across `tasks/`, `memory/`, `.claude/`); clean such orphans manually. Any **foreign** change OUTSIDE the owned surface — modified or staged (e.g. `.codex/config.toml`) — survives byte-for-byte (left in place / left staged) and is ignored by the scoped assertion and the next §1 check:
+**Restore branch** (root mode only — when `$CRON_WORKTREE` is set the whole restore is skipped: a worktree run never touched root and its worktree is discarded by the runtime/heartbeat, so there is nothing to restore. In root mode it is mandatory — the next cron fire's §1 branch guard only passes on `development`). Canonical **scoped restore** — a non-destructive two-step that discards only this run's own OWNED-path residue, then switches HEAD. Committed work is safe on the branch / draft PR. The scope step MUST precede the branch switch (it clears owned residue that would otherwise make a non-forced `git checkout development` refuse). It touches only **tracked** files, so an untracked owned-path orphan from a mid-run crash is NOT auto-removed (`git clean` is deliberately NOT used — too destructive across `tasks/`, `.oh/memory/`, `.claude/`); clean such orphans manually. Any **foreign** change OUTSIDE the owned surface — modified or staged (e.g. `.codex/config.toml`) — survives byte-for-byte (left in place / left staged) and is ignored by the scoped assertion and the next §1 check:
 ```bash
 release_overlap_lock                         # terminal PR state reached; clear cron overlap lock before keeping the Pi session alive
 if [ -z "${CRON_WORKTREE:-}" ]; then         # root mode ONLY — a worktree run is ephemeral (runtime/heartbeat removes the worktree); there is nothing in root to restore
@@ -526,11 +526,11 @@ fi
 
 ### 8. Memory Log
 
-Append to `$AUTOPILOT_LOG_ROOT/memory/<today>/log.md` on **every** exit path (skips, halts, errors included). In worktree-mode runs, `$AUTOPILOT_LOG_ROOT` is the shared root checkout, not the ephemeral cron worktree:
+Append to `$AUTOPILOT_LOG_ROOT/.oh/memory/<today>/log.md` on **every** exit path (skips, halts, errors included). In worktree-mode runs, `$AUTOPILOT_LOG_ROOT` is the shared root checkout, not the ephemeral cron worktree:
 
 ```bash
-TODAY=$(date -u +%Y-%m-%d); TIME=$(date -u +%H:%M); mkdir -p "$AUTOPILOT_LOG_ROOT/memory/$TODAY"
-.oh/scripts/locked-append.sh "$AUTOPILOT_LOG_ROOT/memory/$TODAY/log.md" <<EOF
+TODAY=$(date -u +%Y-%m-%d); TIME=$(date -u +%H:%M); mkdir -p "$AUTOPILOT_LOG_ROOT/.oh/memory/$TODAY"
+.oh/scripts/locked-append.sh "$AUTOPILOT_LOG_ROOT/.oh/memory/$TODAY/log.md" <<EOF
 
 ## Autopilot -- $TIME UTC
 - **Result**: <SKIPPED-CAP-TOTAL | SKIPPED-CAP-DAILY | NOTHING-NEW | PR-READY | PR-DRAFT-CI-RED | PR-DRAFT-EVAL-RED | HALT-CRITIC-GATE | RALPH-INCOMPLETE | DELEGATE-FAIL | BLOCKED-OWNED-WIP | FAIL>
@@ -547,7 +547,7 @@ See `.mifune/skills/retro/references/memory-protocol.md` for the canonical Memor
 ## Guidelines
 
 - **Scope guard**: harness-infra only — skills, rules, docs, scripts, crons, wiki. Never write or modify sandbox application code. Same boundary as `CLAUDE.md` § What You Do NOT Do.
-- **Worktree isolation by default**: `crons/autopilot.md` sets `worktree: true`, so the cron runtime fires every run inside a fresh detached `.worktrees/cron/<session>` worktree (`$CRON_WORKTREE`) and the shared root checkout is NEVER touched for source/branch work. This is what keeps the root clean (no `BLOCKED-OWNED-WIP`-class dirty-env stalls) and means a fire is never silently skipped — it runs isolated, or the runtime surfaces a FAILURE (`ERR_WORKTREE`/`ERR_WORKTREE_CAP`). In worktree mode §1 skips the root-clean guards and §7 skips the branch restore; the overlap lock is moot (no id-scoped pidfile is held). `release_overlap_lock` is retained for root/manual runs (no `$CRON_WORKTREE`) and is a harmless no-op under worktree mode. Stuck/idle worktree sessions and their checkouts are reaped by the heartbeat (and the runtime prunes dead-session worktrees before the concurrency cap). **Runtime observability is the exception**: autopilot resolves `$AUTOPILOT_LOG_ROOT` to the shared root checkout and writes `memory/<today>/log.md` plus `crons/.cron.log` there via `.oh/scripts/locked-append.sh` so those logs survive worktree reaping and remain visible to heartbeat.
+- **Worktree isolation by default**: `crons/autopilot.md` sets `worktree: true`, so the cron runtime fires every run inside a fresh detached `.worktrees/cron/<session>` worktree (`$CRON_WORKTREE`) and the shared root checkout is NEVER touched for source/branch work. This is what keeps the root clean (no `BLOCKED-OWNED-WIP`-class dirty-env stalls) and means a fire is never silently skipped — it runs isolated, or the runtime surfaces a FAILURE (`ERR_WORKTREE`/`ERR_WORKTREE_CAP`). In worktree mode §1 skips the root-clean guards and §7 skips the branch restore; the overlap lock is moot (no id-scoped pidfile is held). `release_overlap_lock` is retained for root/manual runs (no `$CRON_WORKTREE`) and is a harmless no-op under worktree mode. Stuck/idle worktree sessions and their checkouts are reaped by the heartbeat (and the runtime prunes dead-session worktrees before the concurrency cap). **Runtime observability is the exception**: autopilot resolves `$AUTOPILOT_LOG_ROOT` to the shared root checkout and writes `.oh/memory/<today>/log.md` plus `crons/.cron.log` there via `.oh/scripts/locked-append.sh` so those logs survive worktree reaping and remain visible to heartbeat.
 - **Selection rationale**: every PR autopilot opens MUST carry a `## Selection rationale` section as the FIRST section of its description, stating why this item was chosen this session (queue position, or the research finding + impact ranking).
 - **No auto-merge**: autopilot finalizes a *ready-for-review* PR; a human merges. The word "merge" must never appear in an autopilot-generated commit message, PR body, or `gh` command.
 - **Caps**: at most 6 open autopilot PRs created per UTC day AND 10 total open at any time. A close/merge frees a slot.
@@ -587,12 +587,12 @@ See `.mifune/skills/retro/references/memory-protocol.md` for the canonical Memor
 |------|---------|
 | `crons/autopilot.md` | Cron definition (`tmux: true`, `worktree: true`) that fires this skill hourly in an isolated worktree |
 | `$AUTOPILOT_LOG_ROOT/crons/.cron.log` | Append-only liveness log read by the cron runtime; resolves to the shared root checkout when `$CRON_WORKTREE` is set |
-| `$AUTOPILOT_LOG_ROOT/memory/<today>/log.md` | Daily session log; autopilot appends an entry each run; resolves to the shared root checkout when `$CRON_WORKTREE` is set |
+| `$AUTOPILOT_LOG_ROOT/.oh/memory/<today>/log.md` | Daily session log; autopilot appends an entry each run; resolves to the shared root checkout when `$CRON_WORKTREE` is set |
 | `.claude/agents/pm.md` | pm agent definition (invoked via `Agent subagent_type: pm`) |
 | `$CRON_TMUX_SESSION` / `$CRON_KEEP_MARKER` | Per-run tmux session name + keep-marker path, set by the cron runtime (empty on manual runs); the ship-spec/delegate-advisor modes rename the session to `autopilot-<branch>` after branch discovery |
 | `$CRON_OVERLAP_PIDFILE` | Per-id overlap lock path (for autopilot, `/tmp/cron-autopilot.pid`) exported by the cron runtime; terminal PR paths remove it so a kept Pi review session does not trigger hourly `SKIPPED_OVERLAP`. In worktree mode the runtime exports a session-scoped path instead (the id lock is never held), so this is a harmless no-op there |
 | `$CRON_WORKTREE` | Absolute path of the isolated worktree this run executes in, set by the cron runtime for `worktree: true` crons (empty on root/manual runs). When set, §1 skips the root-clean guards and §7 skips the branch restore — the worktree is ephemeral and source work never touches the root checkout |
-| `$AUTOPILOT_LOG_ROOT` | Shared checkout root used only for runtime observability appends (`crons/.cron.log`, `memory/<today>/log.md`); defaults to the current checkout in root/manual mode and resolves above `.worktrees/cron/<session>` in worktree mode |
+| `$AUTOPILOT_LOG_ROOT` | Shared checkout root used only for runtime observability appends (`crons/.cron.log`, `.oh/memory/<today>/log.md`); defaults to the current checkout in root/manual mode and resolves above `.worktrees/cron/<session>` in worktree mode |
 | `AUTOPILOT_REPO` | Canonical GitHub repo target for issues, PRs, labels, and cap counts. Defaults to `mifunedev/openharness`; cron runtime exports it from `repo:` frontmatter. |
 | `AUTOPILOT_REMOTE` | Local git remote whose URL matches `$AUTOPILOT_REPO` (`upstream` in this checkout, normally `origin` in fresh installs). Used for fetch/push. |
 | `AUTOPILOT_EXECUTOR` | Optional executor toggle: `ship-spec` (default, defers to `/ship-spec`), `delegate-advisor` (defer with the `/delegate` fan-out), or `ralph` (legacy inline) |

--- a/skills/autopilot/autopilot-caps.sh
+++ b/skills/autopilot/autopilot-caps.sh
@@ -139,8 +139,8 @@ log_skip() {
   mkdir -p "$root/crons"
   printf '[%s] autopilot: %s\n' "$(date -Iseconds)" "$status" | append_runtime_log "$root/crons/.cron.log"
   day=$(date -u +%Y-%m-%d); time=$(date -u +%H:%M)
-  mkdir -p "$root/memory/$day"
-  append_runtime_log "$root/memory/$day/log.md" <<EOF
+  mkdir -p "$root/.oh/memory/$day"
+  append_runtime_log "$root/.oh/memory/$day/log.md" <<EOF
 
 ## Autopilot -- $time UTC
 - **Result**: $status
@@ -150,7 +150,7 @@ log_skip() {
 - **Action**: $action
 - **Observation**: $observation
 EOF
-  printf 'autopilot-caps: %s — logged to %s/memory/%s/log.md + crons/.cron.log\n' "$status" "$root" "$day" >&2
+  printf 'autopilot-caps: %s — logged to %s/.oh/memory/%s/log.md + crons/.cron.log\n' "$status" "$root" "$day" >&2
 }
 
 # Query open autopilot PR counts. `|| echo ERR` keeps `set -e` from killing us on

--- a/skills/benchmark/SKILL.md
+++ b/skills/benchmark/SKILL.md
@@ -157,7 +157,7 @@ REDIRECT-FLAG: capability suite score flat at <X.XX>/2.00 for <N> cycles while N
 
 ## Memory Protocol
 
-After a run, append to `memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
+After a run, append to `.oh/memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
 
 ```markdown
 ## benchmark -- HH:MM UTC

--- a/skills/caveman-compress/SKILL.md
+++ b/skills/caveman-compress/SKILL.md
@@ -15,7 +15,7 @@ Rewrite a file in compressed form. Read core rules first: `.claude/skills/cavema
 ## Scope (check first — refuse out of scope)
 
 In-scope targets only:
-- files under `memory/**` (notes, daily logs)
+- files under `.oh/memory/**` (notes, daily logs)
 - untracked scratch files (not committed to git)
 - a file the user passes with explicit "compress this anyway" override
 
@@ -36,4 +36,4 @@ Everything else is **out of scope** — refuse with a one-line reason. In partic
 
 - **Never** compress: `LICENSE`, `CHANGELOG.md`, generated/lock files (`*.lock`, `skills.lock`), or anything under `.github/`. These have exact-format contracts.
 - **Refuse** files where compression would break a parser (JSON, YAML data, `prd.json`) — compression is for human-prose docs, not machine-read data.
-- Compressing a `memory/` note is fine; preserve the `## Heading -- HH:MM UTC` log structure (`.mifune/skills/retro/references/memory-protocol.md`).
+- Compressing a `.oh/memory/` note is fine; preserve the `## Heading -- HH:MM UTC` log structure (`.mifune/skills/retro/references/memory-protocol.md`).

--- a/skills/caveman/SKILL.md
+++ b/skills/caveman/SKILL.md
@@ -79,7 +79,7 @@ Each subcommand inherits the **drop/preserve** and **auto-clarity** rules above.
 
 ## Memory protocol
 
-Per `.mifune/skills/retro/references/memory-protocol.md`, append a one-line entry to `memory/<UTC-date>/log.md` after activation:
+Per `.mifune/skills/retro/references/memory-protocol.md`, append a one-line entry to `.oh/memory/<UTC-date>/log.md` after activation:
 
 ```markdown
 ## Caveman -- HH:MM UTC

--- a/skills/context-audit/SKILL.md
+++ b/skills/context-audit/SKILL.md
@@ -20,7 +20,7 @@ Score every file in the default-loaded context set on 4 deterministic dimensions
 |-------|-------|-----------|
 | Bootloader | `CLAUDE.md` | always |
 | Context | `context/SOUL.md`, `context/IDENTITY.md`, `context/TOOLS.md`, `context/USER.md` | session start |
-| Memory | `memory/MEMORY.md` (+ today's log) | session start |
+| Memory | `.oh/memory/MEMORY.md` (+ today's log) | session start |
 | Skill metadata | frontmatter of all `**/SKILL.md` | always injected |
 
 ## Instructions
@@ -32,7 +32,7 @@ Arguments received: `$ARGUMENTS`
 | Argument | Mode |
 |----------|------|
 | empty or `all` | Tier-1 scorecard only |
-| `--baseline` | Tier-1 scorecard + record durable baseline snapshot to `memory/YYYY-MM-DD/context-audit-baseline/` |
+| `--baseline` | Tier-1 scorecard + record durable baseline snapshot to `.oh/memory/YYYY-MM-DD/context-audit-baseline/` |
 | `--ablate <file>` | Tier-1 scorecard + Tier-2 ablation against `<file>` (path relative to harness root) |
 
 ### 2. Inventory the default-loaded set
@@ -48,7 +48,7 @@ for f in \
   "$HARNESS/context/IDENTITY.md" \
   "$HARNESS/context/TOOLS.md" \
   "$HARNESS/context/USER.md" \
-  "$HARNESS/memory/MEMORY.md"; do
+  "$HARNESS/.oh/memory/MEMORY.md"; do
   [ -f "$f" ] || continue
   chars=$(wc -c < "$f")
   words=$(wc -w < "$f")
@@ -237,11 +237,11 @@ for probe in "$PROBE_DIR"/*.md; do
 done
 ```
 
-If `--baseline` mode: copy results to `memory/$TODAY/context-audit-baseline/` for durable storage.
+If `--baseline` mode: copy results to `.oh/memory/$TODAY/context-audit-baseline/` for durable storage.
 
 ```bash
-mkdir -p "$HARNESS/memory/$TODAY/context-audit-baseline"
-cp "$RESULTS"/baseline-*.txt "$HARNESS/memory/$TODAY/context-audit-baseline/"
+mkdir -p "$HARNESS/.oh/memory/$TODAY/context-audit-baseline"
+cp "$RESULTS"/baseline-*.txt "$HARNESS/.oh/memory/$TODAY/context-audit-baseline/"
 ```
 
 #### 6b. Ablation run
@@ -320,8 +320,8 @@ Degradation threshold: **SIGNAL DETECTED** if any probe's ablation hits fall mor
 ### 7. Memory Protocol
 
 ```bash
-mkdir -p "$HARNESS/memory/$TODAY"
-.oh/scripts/locked-append.sh "$HARNESS/memory/$TODAY/log.md" <<EOF
+mkdir -p "$HARNESS/.oh/memory/$TODAY"
+.oh/scripts/locked-append.sh "$HARNESS/.oh/memory/$TODAY/log.md" <<EOF
 
 ## [Context Audit] — $(date -u +%H:%M) UTC
 - **Result**: OP
@@ -341,7 +341,7 @@ See `.mifune/skills/retro/references/memory-protocol.md` for the canonical Memor
 - The skill-metadata aggregate row gets a budget line but no verdict (it's aggregate; verdicts apply per-file only).
 - Tier-2 probe results are probabilistic, not deterministic — `claude -p` is non-deterministic. Run ablation twice if a verdict is borderline.
 - For before/after token diff: the Memory log's `Budget:` line from each run is the comparison data point. No separate snapshot mechanism needed for the diff.
-- When `--baseline` mode is used, probe outputs are persisted to `memory/YYYY-MM-DD/context-audit-baseline/` and are gitignored (daily memory dirs are gitignored per `.gitignore`).
+- When `--baseline` mode is used, probe outputs are persisted to `.oh/memory/YYYY-MM-DD/context-audit-baseline/` and are gitignored (daily memory dirs are gitignored per `.gitignore`).
 - Do not penalize `CLAUDE.md` on Dimension B (load-bearing) because it's the source of truth and may have few inbound citations by design — it doesn't need to be cited; it is the orchestrator instructions.
 
 ## Reference

--- a/skills/context-audit/runner.sh
+++ b/skills/context-audit/runner.sh
@@ -91,10 +91,10 @@ if [ "$MODE" = "--baseline" ]; then
   echo "=== Baseline probe run ==="
   run_probes "baseline"
   # Persist to memory for durable comparison
-  mkdir -p "$HARNESS/memory/$TODAY/context-audit-baseline"
-  cp "$RESULTS"/baseline-*.txt "$HARNESS/memory/$TODAY/context-audit-baseline/"
+  mkdir -p "$HARNESS/.oh/memory/$TODAY/context-audit-baseline"
+  cp "$RESULTS"/baseline-*.txt "$HARNESS/.oh/memory/$TODAY/context-audit-baseline/"
   echo ""
-  echo "Baseline saved → memory/$TODAY/context-audit-baseline/"
+  echo "Baseline saved → .oh/memory/$TODAY/context-audit-baseline/"
   exit 0
 fi
 

--- a/skills/critique/SKILL.md
+++ b/skills/critique/SKILL.md
@@ -148,7 +148,7 @@ none → `PROCEED`. This node only *records* that judgment — the binding decis
 
 ## Memory Protocol
 
-After a run, append to `memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
+After a run, append to `.oh/memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
 
 ```markdown
 ## critique -- HH:MM UTC

--- a/skills/delegate/SKILL.md
+++ b/skills/delegate/SKILL.md
@@ -212,7 +212,7 @@ Output a structured summary:
 
 Run at the end of **every** execution -- op, dry-run, or error.
 
-**a) Log** -- append to `memory/<today>/log.md` where today = `date -u +%Y-%m-%d`:
+**a) Log** -- append to `.oh/memory/<today>/log.md` where today = `date -u +%Y-%m-%d`:
 
 ```markdown
 ## Delegate -- HH:MM UTC
@@ -246,6 +246,6 @@ See `.mifune/skills/retro/references/memory-protocol.md` for the canonical Memor
 | Agent: Council | `.claude/agents/council.md` |
 | Identity | `IDENTITY.md` |
 | Memory | `MEMORY.md` |
-| Daily Logs | `memory/YYYY-MM-DD/log.md` |
+| Daily Logs | `.oh/memory/YYYY-MM-DD/log.md` |
 
 The `implementer`/`pm`/`critic` agent types above are read-only and will silently make zero file changes. For any worker that must `Write`/`Edit` files, set `subagent_type: general-purpose` (or `claude`) — both are built-in agent types with no agent-definition file, so there is no `.claude/agents/` path to reference.

--- a/skills/drift-check/SKILL.md
+++ b/skills/drift-check/SKILL.md
@@ -104,8 +104,8 @@ rename history), print `  (no changed paths detected — inspect manually)`.
 
 **Goal**: detect whether HEAD is behind its remote tracking branch, the
 working tree is dirty, or the current branch is unexpected. This section
-is motivated by the append-only-file stale-view trap: `memory/MEMORY.md`
-and `memory/<date>/log.md` are appended by concurrent sessions; if HEAD
+is motivated by the append-only-file stale-view trap: `.oh/memory/MEMORY.md`
+and `.oh/memory/<date>/log.md` are appended by concurrent sessions; if HEAD
 drifts behind `origin/<branch>`, the in-context view of these files lags
 behind reality.
 

--- a/skills/eval/SKILL.md
+++ b/skills/eval/SKILL.md
@@ -73,7 +73,7 @@ US-006 in `tasks/context-fitness-evals/prd.md`.
 
 ## Memory Protocol
 
-After a run, append to `memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
+After a run, append to `.oh/memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
 
 ```markdown
 ## eval -- HH:MM UTC

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -30,16 +30,16 @@ Before every commit or PR, inspect the changed paths and choose the remote
 explicitly. Do not assume `origin` is the public target.
 
 **Memory is private. Never commit memory artifacts to the public upstream repo.**
-Anything under `memory/` — especially `memory/MEMORY.md`, dated session logs,
+Anything under `.oh/memory/` — especially `.oh/memory/MEMORY.md`, dated session logs,
 retro notes, and private lessons — belongs only in your private fork
 (`origin`) unless the operator gives an explicit one-off exception. If a public
-PR branch contains `memory/` changes, remove them before pushing/creating the PR,
+PR branch contains `.oh/memory/` changes, remove them before pushing/creating the PR,
 and preserve them separately on an `origin`-only branch or PR.
 
 Use this quick guard before pushing to `upstream`:
 
 ```bash
-git diff --name-only upstream/development...HEAD | grep '^memory/' \
+git diff --name-only upstream/development...HEAD | grep '^.oh/memory/' \
   && { echo "BLOCK: memory changes must go to origin only"; exit 1; }
 ```
 

--- a/skills/harness-audit/SKILL.md
+++ b/skills/harness-audit/SKILL.md
@@ -74,7 +74,7 @@ fi
 ls "$AUDIT_ROOT/.claude/skills/"
 ls "$AUDIT_ROOT/.claude/agents/" 2>/dev/null || echo "no agents dir"
 ls "$AUDIT_ROOT/crons/" 2>/dev/null || echo "no crons"
-ls "$AUDIT_LOG_ROOT/memory/" 2>/dev/null | tail -10
+ls "$AUDIT_LOG_ROOT/.oh/memory/" 2>/dev/null | tail -10
 ls "$AUDIT_ROOT/.mifune/skills/wiki/corpus/" 2>/dev/null | head -20
 
 # Package health
@@ -90,11 +90,11 @@ git -C "$AUDIT_ROOT" worktree list 2>/dev/null
 # Recent long-term memory (durable shared artifact). In cron worktree mode,
 # source inspection stays on AUDIT_ROOT, but long-term lessons live in the
 # shared checkout resolved as AUDIT_LOG_ROOT.
-if [ -r "$AUDIT_LOG_ROOT/memory/MEMORY.md" ]; then
-  printf 'long_term_memory: loaded %s\n' "$AUDIT_LOG_ROOT/memory/MEMORY.md"
-  tail -40 "$AUDIT_LOG_ROOT/memory/MEMORY.md"
+if [ -r "$AUDIT_LOG_ROOT/.oh/memory/MEMORY.md" ]; then
+  printf 'long_term_memory: loaded %s\n' "$AUDIT_LOG_ROOT/.oh/memory/MEMORY.md"
+  tail -40 "$AUDIT_LOG_ROOT/.oh/memory/MEMORY.md"
 else
-  printf 'long_term_memory: missing-or-unreadable %s\n' "$AUDIT_LOG_ROOT/memory/MEMORY.md"
+  printf 'long_term_memory: missing-or-unreadable %s\n' "$AUDIT_LOG_ROOT/.oh/memory/MEMORY.md"
 fi
 ```
 
@@ -154,7 +154,7 @@ Launch 4 Agent tool calls **in a single message**. Each receives the Context Sna
 >
 > 3. **Issue template completeness** — List `.github/ISSUE_TEMPLATE/` files. For each template, check: does it have required fields, clear labels, and assignment guidance?
 >
-> 4. **Wiki/memory utilization** — Count wiki pages under `.mifune/skills/wiki/corpus/`. Count daily memory logs under `memory/`. Are logs recent (within 7 days)? Are wiki pages populated or placeholder-empty?
+> 4. **Wiki/memory utilization** — Count wiki pages under `.mifune/skills/wiki/corpus/`. Count daily memory logs under `.oh/memory/`. Are logs recent (within 7 days)? Are wiki pages populated or placeholder-empty?
 >
 > **Return format (Ultra compression):**
 > ```
@@ -228,7 +228,7 @@ Launch 4 Agent tool calls **in a single message**. Each receives the Context Sna
 >
 > **Audit areas:**
 >
-> 1. **Memory system quality** — Use the Context Snapshot's `AUDIT_LOG_ROOT` memory/log context (not `AUDIT_ROOT` when they differ) to inspect the 5 most recent daily logs. Are entries following the Memory Improvement Protocol (Result/Action/Observation/Duration)? Is quality declining over time (shorter entries, missing fields)? Are entries actually present? Report if `long_term_memory` is `missing-or-unreadable`.
+> 1. **Memory system quality** — Use the Context Snapshot's `AUDIT_LOG_ROOT` .oh/memory/log context (not `AUDIT_ROOT` when they differ) to inspect the 5 most recent daily logs. Are entries following the Memory Improvement Protocol (Result/Action/Observation/Duration)? Is quality declining over time (shorter entries, missing fields)? Are entries actually present? Report if `long_term_memory` is `missing-or-unreadable`.
 >
 > 2. **Wiki utilization** — List all files under `.mifune/skills/wiki/corpus/`. For each, check if it has substantive content (>10 lines) or is a placeholder stub. What percentage is populated?
 >
@@ -318,7 +318,7 @@ After all 4 auditors return and pass the auditor-output validation gate, synthes
 
 ### 6. Memory Protocol
 
-Append to `memory/YYYY-MM-DD/log.md` where today = `date -u +%Y-%m-%d`:
+Append to `.oh/memory/YYYY-MM-DD/log.md` where today = `date -u +%Y-%m-%d`:
 
 ```markdown
 ## [Harness Audit] — HH:MM UTC
@@ -355,8 +355,8 @@ See `.mifune/skills/retro/references/memory-protocol.md` for the canonical Memor
 | Orchestrator skills | `.claude/skills/` |
 | Workspace skills | `workspace/.claude/skills/` when created by a pack/runtime (not part of the minimal workspace template) |
 | Crons | `crons/` |
-| Memory logs | `memory/YYYY-MM-DD/log.md` |
-| Long-term memory | `memory/MEMORY.md` |
+| Memory logs | `.oh/memory/YYYY-MM-DD/log.md` |
+| Long-term memory | `.oh/memory/MEMORY.md` |
 | Wiki | `.mifune/skills/wiki/corpus/` |
 | Compose | `.devcontainer/docker-compose.yml` |
 | Entrypoint | `.devcontainer/entrypoint.sh` |

--- a/skills/health-check/SKILL.md
+++ b/skills/health-check/SKILL.md
@@ -148,8 +148,8 @@ Then ask (use `AskUserQuestion`). Run the removal only on explicit approval. Wit
 Always, per `.mifune/skills/retro/references/memory-protocol.md`:
 
 ```bash
-TODAY=$(date -u +%Y-%m-%d); TIME=$(date -u +%H:%M); mkdir -p "memory/$TODAY"
-.oh/scripts/locked-append.sh "memory/$TODAY/log.md" <<EOF
+TODAY=$(date -u +%Y-%m-%d); TIME=$(date -u +%H:%M); mkdir -p ".oh/memory/$TODAY"
+.oh/scripts/locked-append.sh ".oh/memory/$TODAY/log.md" <<EOF
 
 ## Health-Check -- $TIME UTC
 - **Result**: OP | DRY-RUN

--- a/skills/imagine/SKILL.md
+++ b/skills/imagine/SKILL.md
@@ -128,7 +128,7 @@ Next: /ship-spec --plan .claude/specs/<slug>/spec.md
 
 ## Step 5 — Memory Protocol
 
-Per `.mifune/skills/retro/references/memory-protocol.md`, append to `memory/<UTC-date>/log.md` (create the dated directory if missing):
+Per `.mifune/skills/retro/references/memory-protocol.md`, append to `.oh/memory/<UTC-date>/log.md` (create the dated directory if missing):
 
 ```markdown
 ## imagine -- HH:MM UTC
@@ -139,14 +139,14 @@ Per `.mifune/skills/retro/references/memory-protocol.md`, append to `memory/<UTC
 - **Observation**: <one sentence on whether the scenario was rich enough to one-shot, or whether the open-questions section had to carry the weight>
 ```
 
-Then run the qualify/improve loop per `.mifune/skills/retro/references/memory-protocol.md`. Lessons about scenario-quality patterns (e.g. "scenarios under 10 words usually need a follow-up `/prd` pass") may belong in `memory/MEMORY.md`.
+Then run the qualify/improve loop per `.mifune/skills/retro/references/memory-protocol.md`. Lessons about scenario-quality patterns (e.g. "scenarios under 10 words usually need a follow-up `/prd` pass") may belong in `.oh/memory/MEMORY.md`.
 
 ## Anti-patterns
 
 - **Asking clarifying questions.** Breaks the one-shot contract. If the scenario is too vague, push the ambiguities into `## Open questions for /prd`; do not interrupt.
 - **Writing a full PRD.** Story seeds are one-liners. Numbered functional requirements, acceptance criteria, success metrics — all `/prd`'s job, not this skill's.
 - **Skipping the mermaid diagram.** The diagram is the cheapest forcing function for "did I actually understand the scenario?" Pick a real type; never emit a placeholder or `// TODO: diagram`.
-- **Writing outside `.claude/specs/<slug>/`.** No spillover into `tasks/`, `memory/<topic>.md`, `.mifune/skills/wiki/corpus/`, or root. Those surfaces have their own skills.
+- **Writing outside `.claude/specs/<slug>/`.** No spillover into `tasks/`, `.oh/memory/<topic>.md`, `.mifune/skills/wiki/corpus/`, or root. Those surfaces have their own skills.
 - **Auto-chaining into `/ship-spec`.** Keep the seam explicit. The user edits the spec before formalizing — that's the entire reason the seam exists.
 - **Truncating the scenario into the slug.** `imagine a long thirty word scenario about ...` → derive the noun phrase (`thirty-word-scenario` or `long-scenario`), not the first five words verbatim.
 

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -68,7 +68,7 @@ If the user types **STOP** during the brief, halt — do not finish the thought,
 
 ### 6. Memory Protocol
 
-Append to `memory/<UTC-date>/log.md`:
+Append to `.oh/memory/<UTC-date>/log.md`:
 
 ```markdown
 ## interview -- HH:MM UTC
@@ -78,7 +78,7 @@ Append to `memory/<UTC-date>/log.md`:
 - **Observation**: <one sentence on whether the questions landed (changed the work, or were noise)>
 ```
 
-Then run the qualify/improve loop per `.mifune/skills/retro/references/memory-protocol.md`. If a question pattern landed especially well or poorly across runs, that may merit a line in `memory/MEMORY.md`.
+Then run the qualify/improve loop per `.mifune/skills/retro/references/memory-protocol.md`. If a question pattern landed especially well or poorly across runs, that may merit a line in `.oh/memory/MEMORY.md`.
 
 ## Question quality bar
 

--- a/skills/pr-audit/SKILL.md
+++ b/skills/pr-audit/SKILL.md
@@ -327,7 +327,7 @@ Default does nothing here. Each requires an explicit flag and a confirmation.
 
 ### 8. Memory Protocol
 
-Append to `memory/$(date -u +%Y-%m-%d)/log.md` (create the dir first):
+Append to `.oh/memory/$(date -u +%Y-%m-%d)/log.md` (create the dir first):
 
 ```markdown
 ## PR Audit -- HH:MM UTC

--- a/skills/prompt-miner/SKILL.md
+++ b/skills/prompt-miner/SKILL.md
@@ -43,9 +43,9 @@ content. The contract is non-negotiable:
 - `--include-prompt-text` applies a redaction pass (line-level token patterns +
   block-level key bodies) and prints a `WARNING` banner. Use it only when you must
   read the prompt wording, and never commit the result.
-- All artifacts land in the **gitignored** `memory/<UTC-date>/` directory. Never
+- All artifacts land in the **gitignored** `.oh/memory/<UTC-date>/` directory. Never
   stage, commit, or paste a transcript or an `--include-prompt-text` report.
-- The engine never edits `memory/MEMORY.md` or `context/IDENTITY.md`. Only Step 4
+- The engine never edits `.oh/memory/MEMORY.md` or `context/IDENTITY.md`. Only Step 4
   of this skill writes there, and only after explicit `APPROVE`.
 
 ## When to use
@@ -93,7 +93,7 @@ node "${CLAUDE_SKILL_DIR}/scripts/mine-traces.mjs" "${args[@]}"
 ```
 
 The engine writes `prompt-miner-<UTC-date>.json` + `.md` to `--out`
-(default `memory/<UTC-date>/`), unless `--dry-run` was passed (it prints the JSON
+(default `.oh/memory/<UTC-date>/`), unless `--dry-run` was passed (it prints the JSON
 dataset to stdout and writes nothing). The flag surface (defaults in parens):
 
 - `--harness all|claude|pi` (all), `--since`/`--until` (YYYY-MM-DD),
@@ -161,11 +161,11 @@ then gate it exactly like `/retro` (`.claude/skills/retro/SKILL.md` § 6):
    Go in Memory" table (`.mifune/skills/retro/references/memory-protocol.md`) — secrets, raw output, plans,
    anything re-derivable in under a minute.
 2. **Dedup against existing memory.** For each surviving candidate, grep
-   `memory/MEMORY.md` and `context/IDENTITY.md` for the same substance; if it is
+   `.oh/memory/MEMORY.md` and `context/IDENTITY.md` for the same substance; if it is
    already captured, link or skip — never double-write (this is the same dedup
    `/retro` performs in its qualify filter).
 3. **Tier classification.** A marker is descriptive ("this corpus shows X prompt
-   trait correlates with better `<type>` sessions") → `memory/MEMORY.md`. Only a
+   trait correlates with better `<type>` sessions") → `.oh/memory/MEMORY.md`. Only a
    marker that has generalized across many sessions into a prescriptive principle
    ("always include acceptance criteria") earns a `context/IDENTITY.md` proposal —
    and IDENTITY.md is **never** auto-written.
@@ -181,7 +181,7 @@ then gate it exactly like `/retro` (`.claude/skills/retro/SKILL.md` § 6):
    Type APPROVE to write, SKIP to discard any item, or EDIT <n> <new text> to revise.
    ```
 
-5. **Write approved items.** On `APPROVE`, append to `memory/MEMORY.md` under
+5. **Write approved items.** On `APPROVE`, append to `.oh/memory/MEMORY.md` under
    `## Lessons Learned` (and, if approved, `context/IDENTITY.md` under
    `## Lessons learned (append-only)`). Both files are append-only; never edit
    existing entries. `--report-only` and `--dry-run` skip this step entirely.
@@ -203,7 +203,7 @@ bash "${CLAUDE_SKILL_DIR}/scripts/render-log-entry.sh" \
   --top-marker "<one-line strongest marker, or 'none'>"
 ```
 
-The helper writes only to `memory/<UTC-date>/log.md` — never to `MEMORY.md` or
+The helper writes only to `.oh/memory/<UTC-date>/log.md` — never to `MEMORY.md` or
 `IDENTITY.md`. Even `--report-only` runs emit this daily-log line (the engine's
 `--report-only` contract: report + daily log, but no MEMORY/IDENTITY mutation).
 

--- a/skills/prompt-miner/references/report-schema.md
+++ b/skills/prompt-miner/references/report-schema.md
@@ -1,6 +1,6 @@
 # prompt-miner — Report Schema
 
-`mine-traces.mjs` emits two artifacts to `--out` (default `memory/<UTC-date>/`):
+`mine-traces.mjs` emits two artifacts to `--out` (default `.oh/memory/<UTC-date>/`):
 
 - `prompt-miner-<UTC-date>.json` — the full dataset (below).
 - `prompt-miner-<UTC-date>.md` — manifest + ranked top-N / bottom-N table.
@@ -9,7 +9,7 @@
 contains **feature vectors + metadata only — never raw prompt text**;
 `--include-prompt-text` adds a redacted `promptText` field per session and prints
 a `WARNING` banner to stderr. `--report-only` writes the report only and never
-mutates `memory/MEMORY.md` / `context/IDENTITY.md` — the engine never edits those
+mutates `.oh/memory/MEMORY.md` / `context/IDENTITY.md` — the engine never edits those
 regardless; the flag documents that contract for the SKILL layer.
 
 ## Top-level dataset

--- a/skills/prompt-miner/scripts/mine-traces.mjs
+++ b/skills/prompt-miner/scripts/mine-traces.mjs
@@ -523,7 +523,7 @@ const USAGE = `usage: mine-traces.mjs [options]
   --include-prompt-text     emit redacted prompt text (default off)
   --no-git                  stub the ground-truth bonus to 0
   --weights <json>          override friction weights (all keys required)
-  --out <dir>               output dir (default memory/<UTC-date>/)
+  --out <dir>               output dir (default .oh/memory/<UTC-date>/)
   --report-only             write the report only (no MEMORY/IDENTITY mutation)
   --dry-run                 print to stdout; write nothing
   --max-file-mb N          (default 50) skip files larger than this

--- a/skills/prompt-miner/scripts/render-log-entry.sh
+++ b/skills/prompt-miner/scripts/render-log-entry.sh
@@ -3,9 +3,9 @@
 #
 # Mirrors the autopilot/caps logging shape: it resolves the shared harness root
 # (git rev-parse --show-toplevel) and appends a single Memory-Improvement-Protocol
-# record to memory/<UTC-date>/log.md through the repo-root .oh/scripts/locked-append.sh
+# record to .oh/memory/<UTC-date>/log.md through the repo-root .oh/scripts/locked-append.sh
 # helper so the whole multi-line record is serialized under flock. Diagnostics go
-# to stderr; the helper never edits memory/MEMORY.md or context/IDENTITY.md.
+# to stderr; the helper never edits .oh/memory/MEMORY.md or context/IDENTITY.md.
 #
 # Flags (all optional except --result):
 #   --result <MINING-COMPLETE|DRY-RUN|NO-SESSIONS|NO-CORPUS>  the run's RESULT tag
@@ -45,7 +45,7 @@ DAY="$(date -u +%Y-%m-%d)"
 # current toplevel; the cron path may export AUTOPILOT_LOG_ROOT to redirect the
 # write to the shared root checkout (matching the autopilot convention).
 ROOT="${AUTOPILOT_LOG_ROOT:-$(git rev-parse --show-toplevel)}"
-LOG_DIR="$ROOT/memory/$DAY"
+LOG_DIR="$ROOT/.oh/memory/$DAY"
 LOG_FILE="$LOG_DIR/log.md"
 APPEND="$ROOT/.oh/scripts/locked-append.sh"
 mkdir -p "$LOG_DIR"

--- a/skills/render-html/SKILL.md
+++ b/skills/render-html/SKILL.md
@@ -3,7 +3,7 @@ name: render-html
 description: |
   Render an artifact (or in-context material) as a bespoke, self-contained
   HTML file for one-shot human consumption. Writes to
-  memory/<UTC-date>/<slug>.html. Output is gitignored — these are
+  .oh/memory/<UTC-date>/<slug>.html. Output is gitignored — these are
   consumption artifacts, not source.
   TRIGGER when: asked to render HTML, generate an HTML report, visualize an
   audit/council/lint/digest, "make this readable", "make a dashboard for",
@@ -34,7 +34,7 @@ Common targets in this harness:
 
 Skip when the artifact is **source or pipeline input** — Markdown stays the substrate of the harness:
 - PRDs (`tasks/*/prd.md`), briefings, commit messages, PR bodies, `CHANGELOG.md`
-- Memory log entries themselves (`memory/<date>/log.md`)
+- Memory log entries themselves (`.oh/memory/<date>/log.md`)
 - Skill/identity sources (`CLAUDE.md`, `context/`, `.claude/skills/`)
 - Agent-to-agent handoffs (advisor → executor briefings)
 
@@ -60,8 +60,8 @@ If `slug` collides with an existing file in today's date directory, append `-2`,
 
 ```bash
 TODAY=$(date -u +%Y-%m-%d)
-mkdir -p "memory/$TODAY"
-OUT="memory/$TODAY/<slug>.html"
+mkdir -p ".oh/memory/$TODAY"
+OUT=".oh/memory/$TODAY/<slug>.html"
 ```
 
 Always use UTC. Always create the directory first.
@@ -98,13 +98,13 @@ Use the `Write` tool. Confirm the byte size is plausible (>2 KB for any non-triv
 ### 6. Report to the user
 
 Return three lines:
-1. Absolute path: `memory/<date>/<slug>.html`
+1. Absolute path: `.oh/memory/<date>/<slug>.html`
 2. A one-sentence summary of what was rendered (so the user knows what they'll see).
-3. The open command suggestion: `/agent-browser file://$(pwd)/memory/<date>/<slug>.html` (or `open file://...` if running locally).
+3. The open command suggestion: `/agent-browser file://$(pwd)/.oh/memory/<date>/<slug>.html` (or `open file://...` if running locally).
 
 ### 7. Memory Protocol
 
-Append to `memory/<UTC-date>/log.md`:
+Append to `.oh/memory/<UTC-date>/log.md`:
 
 ```markdown
 ## render-html -- HH:MM UTC
@@ -112,12 +112,12 @@ Append to `memory/<UTC-date>/log.md`:
 - **Slug**: <slug>
 - **Source**: <path or "in-context">
 - **Intent**: <one-line>
-- **Path**: memory/<date>/<slug>.html
+- **Path**: .oh/memory/<date>/<slug>.html
 - **Size**: <bytes>
 - **Observation**: <one sentence — what shape the artifact took, e.g. "filterable severity table with 17 rows + inline SVG dependency map">
 ```
 
-Then run the qualify/improve loop per `.mifune/skills/retro/references/memory-protocol.md`. If you learned something non-obvious about which HTML shape suited this artifact type, that may merit a line in `memory/MEMORY.md`.
+Then run the qualify/improve loop per `.mifune/skills/retro/references/memory-protocol.md`. If you learned something non-obvious about which HTML shape suited this artifact type, that may merit a line in `.oh/memory/MEMORY.md`.
 
 ## Anti-patterns
 
@@ -126,20 +126,20 @@ Then run the qualify/improve loop per `.mifune/skills/retro/references/memory-pr
 - **Decorative JS.** Animations, fade-ins, gradients. The reader is making a decision, not watching a demo.
 - **Rendering source.** Producing `prd.html`, `CLAUDE.html`, `MEMORY.html`. Those files are pipeline input or indexed source — leave them in Markdown.
 - **Multi-file output.** Separate `.css`/`.js` companions. Single file or nothing.
-- **Writing outside `memory/<date>/`.** No exceptions. The location is the convention.
+- **Writing outside `.oh/memory/<date>/`.** No exceptions. The location is the convention.
 - **Overwriting an existing artifact.** Suffix `-2`, `-3` instead — older renders may still be referenced in the conversation.
 - **Skipping the memory log.** Every run logs, op or fail. The qualify/improve loop is not optional.
 
 ## Examples
 
 ```
-/render-html harness-audit-tier --from memory/2026-05-18/audit-raw.md --intent "pick next 3 actions"
-→ memory/2026-05-18/harness-audit-tier.html
+/render-html harness-audit-tier --from .oh/memory/2026-05-18/audit-raw.md --intent "pick next 3 actions"
+→ .oh/memory/2026-05-18/harness-audit-tier.html
 
 /render-html roadmap-council --intent "review council deliberation before publishing pinned issue"
-→ memory/2026-05-18/roadmap-council.html
+→ .oh/memory/2026-05-18/roadmap-council.html
   (source was the strategic-proposal output already in context)
 
-/render-html week-19-digest --from memory/ --intent "what shipped this week"
-→ memory/2026-05-18/week-19-digest.html
+/render-html week-19-digest --from .oh/memory/ --intent "what shipped this week"
+→ .oh/memory/2026-05-18/week-19-digest.html
 ```

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -7,7 +7,7 @@ description: |
   turn each signal into a falsifiable hypothesis, cite session evidence for
   AND against it, assign a verdict (supported / refuted / inconclusive) and a
   confidence level, then promote only supported, sufficiently-confident
-  hypotheses into the harness memory tiers (memory/MEMORY.md,
+  hypotheses into the harness memory tiers (.oh/memory/MEMORY.md,
   context/IDENTITY.md) behind a propose-then-confirm gate. Reflects on six
   learning/knowledge subsystems through the lens of this session — continual
   learning, context compression, reinforcement learning, wiki, docs, and
@@ -21,7 +21,7 @@ description: |
 
 # Retro
 
-Scientific session-closing retrospective. Turn the current conversation's signals into falsifiable hypotheses, test each against session evidence (for and against), assign a verdict and confidence, and promote only the supported, sufficiently-confident ones — with explicit confirmation — into the harness memory tiers (`memory/MEMORY.md`, `context/IDENTITY.md`). Always appends a log entry regardless of outcome.
+Scientific session-closing retrospective. Turn the current conversation's signals into falsifiable hypotheses, test each against session evidence (for and against), assign a verdict and confidence, and promote only the supported, sufficiently-confident ones — with explicit confirmation — into the harness memory tiers (`.oh/memory/MEMORY.md`, `context/IDENTITY.md`). Always appends a log entry regardless of outcome.
 
 This is the deliberate "Improve" pass of the Memory Improvement Protocol defined in `.mifune/skills/retro/references/memory-protocol.md`, now evidence-driven. Running it as a named skill turns an optional afterthought into a first-class, propose-then-confirm operation — and the scientific layer guards against overfitting a single session into a durable lesson.
 
@@ -95,7 +95,7 @@ Every signal from the session passes through four moves before it can become a m
 
 **Promotion rule:**
 
-- Only `supported` + `medium`-or-higher confidence may reach `memory/MEMORY.md`.
+- Only `supported` + `medium`-or-higher confidence may reach `.oh/memory/MEMORY.md`.
 - `context/IDENTITY.md` *additionally* requires cross-session generalization (a single session, however well-supported, is not a principle).
 - `refuted`, `inconclusive`, and any `low`-confidence hypothesis stay in the log only — never promoted.
 
@@ -105,7 +105,7 @@ Seed hypotheses by asking, for each subsystem, what *this session* revealed abou
 
 | Subsystem | Guiding question (what did this session reveal?) | Lives in / deep-dive skill |
 |-----------|--------------------------------------------------|----------------------------|
-| Continual learning | Did prior memory/identity get used, ignored, or contradicted? Did anything durable emerge? | `memory/MEMORY.md`, `context/IDENTITY.md` |
+| Continual learning | Did prior memory/identity get used, ignored, or contradicted? Did anything durable emerge? | `.oh/memory/MEMORY.md`, `context/IDENTITY.md` |
 | Context compression | Was loaded context bloated/redundant, or did a rule prove load-bearing? | `/context-audit`, `/caveman` |
 | Reinforcement learning | Did advisor/executor or recursive-delegation patterns help or hurt? Over/under-delegation? | `.mifune/skills/advisor/SKILL.md`, `recursive-delegation.md` |
 | Wiki | Did the session surface knowledge that belongs in the wiki, or hit stale/missing entries? | `/wiki ingest`, `/wiki lint` |
@@ -145,7 +145,7 @@ Discard any surviving hypothesis that matches a row in the "What Does NOT Go in 
 | Is a step-by-step task plan | Plans belong in `tasks/<name>/prd.json` |
 | Re-derivable in under a minute | Reading one file answers it — don't memorize |
 
-Also discard any hypothesis already captured, verbatim or in substance, in `memory/MEMORY.md` or `context/IDENTITY.md` — link or skip; never double-write. Finally, drop from promotion every hypothesis whose verdict is `refuted` or `inconclusive`, or whose confidence is `low` (these remain in the log only).
+Also discard any hypothesis already captured, verbatim or in substance, in `.oh/memory/MEMORY.md` or `context/IDENTITY.md` — link or skip; never double-write. Finally, drop from promotion every hypothesis whose verdict is `refuted` or `inconclusive`, or whose confidence is `low` (these remain in the log only).
 
 ### 5. Classify survivors by tier
 
@@ -153,8 +153,8 @@ For each surviving hypothesis — now carrying its evidence and confidence — c
 
 | Tier | Write to | Criterion |
 |------|----------|-----------|
-| **Log** | `memory/<UTC-date>/log.md` | Transient observation: true of this run, not necessarily future ones. Free to write. |
-| **MEMORY.md** | `memory/MEMORY.md` under `## Lessons Learned` | Experiential, session-specific: "this session showed X is true of this codebase." Descriptive tone. Propose-then-confirm. |
+| **Log** | `.oh/memory/<UTC-date>/log.md` | Transient observation: true of this run, not necessarily future ones. Free to write. |
+| **MEMORY.md** | `.oh/memory/MEMORY.md` under `## Lessons Learned` | Experiential, session-specific: "this session showed X is true of this codebase." Descriptive tone. Propose-then-confirm. |
 | **IDENTITY.md** | `context/IDENTITY.md` under `## Lessons learned (append-only)` | Graduated principle: applies across contexts, not just this run. Prescriptive tone ("always X"). **Never auto-write.** Propose a diff for approval. A lesson earns this only when it generalizes across sessions. |
 
 When in doubt between MEMORY.md and IDENTITY.md: if you would scope it to "this session" or "this codebase right now," it belongs in MEMORY.md. If you would remove the scoping and say "always," it belongs in IDENTITY.md.
@@ -181,7 +181,7 @@ The probe id follows the pattern `<subsystem-slug>-<YYYYMMDD>` (e.g., `memory-sc
 
 ### 6. Propose-then-confirm gate
 
-Before writing to `memory/MEMORY.md` or `context/IDENTITY.md`, present the proposed additions as a clearly formatted block. Each proposed line shows its `[subsystem · confidence]` tag and a one-clause evidence basis:
+Before writing to `.oh/memory/MEMORY.md` or `context/IDENTITY.md`, present the proposed additions as a clearly formatted block. Each proposed line shows its `[subsystem · confidence]` tag and a one-clause evidence basis:
 
 ```
 Proposed MEMORY.md addition(s):
@@ -193,7 +193,7 @@ Proposed IDENTITY.md addition(s):
 Type APPROVE to write, SKIP to discard any item, or EDIT <n> <new text> to revise.
 ```
 
-Do not write to either file until the user responds. Log-tier entries do not require approval. If `--dry-run` was passed, write only the required `memory/<UTC-date>/log.md` entry with `Result: DRY-RUN`; never write MEMORY.md or IDENTITY.md in dry-run mode.
+Do not write to either file until the user responds. Log-tier entries do not require approval. If `--dry-run` was passed, write only the required `.oh/memory/<UTC-date>/log.md` entry with `Result: DRY-RUN`; never write MEMORY.md or IDENTITY.md in dry-run mode.
 
 Before proposing, pipe candidate lines through the self-contained duplicate helper and skip exact/substantive duplicates it reports:
 
@@ -205,7 +205,7 @@ printf "%s\n" "<candidate line>" | bash "${CLAUDE_SKILL_DIR}/scripts/check-memor
 
 For each APPROVED item:
 
-**`memory/MEMORY.md`** — append under `## Lessons Learned`:
+**`.oh/memory/MEMORY.md`** — append under `## Lessons Learned`:
 ```markdown
 - **YYYY-MM-DD**: <lesson>
 ```
@@ -224,7 +224,7 @@ Always run this step, regardless of whether anything was promoted. Get the curre
 ```bash
 date -u +%H:%M
 TODAY=$(date -u +%Y-%m-%d)
-mkdir -p "memory/$TODAY"
+mkdir -p ".oh/memory/$TODAY"
 ```
 
 Render the log entry with the skill-local helper, then append it with the shared locked append primitive:
@@ -236,14 +236,14 @@ LOG_ENTRY=$(bash "${CLAUDE_SKILL_DIR}/scripts/render-log-entry.sh" \
   --hypotheses <total> --supported <n> --refuted <n> --inconclusive <n> \
   --memory <n> --identity <n> \
   --observation "<one sentence — strongest supported finding, or no durable patterns>")
-printf "%s\n" "$LOG_ENTRY" | .oh/scripts/locked-append.sh "memory/$TODAY/log.md"
+printf "%s\n" "$LOG_ENTRY" | .oh/scripts/locked-append.sh ".oh/memory/$TODAY/log.md"
 ```
 
 Use `--result DRY-RUN` for dry-runs and `--result SKIPPED-TRIVIAL` for trivial skips.
 
 ## MEMORY.md vs IDENTITY.md boundary
 
-| | `memory/MEMORY.md` | `context/IDENTITY.md` |
+| | `.oh/memory/MEMORY.md` | `context/IDENTITY.md` |
 |-|--------------------|-----------------------|
 | **Tone** | Descriptive — "this session showed…" | Prescriptive — "always X", "never Y" |
 | **Scope** | Session or codebase-specific observation | Generalizes across contexts |

--- a/skills/retro/references/memory-protocol.md
+++ b/skills/retro/references/memory-protocol.md
@@ -10,11 +10,11 @@ Memory operates on two tiers:
 
 | Tier | Path | What it holds |
 |------|------|---------------|
-| Daily log | `memory/YYYY-MM-DD/log.md` | Time-stamped entries from each skill or agent run that day |
-| Long-term lessons | `memory/MEMORY.md` | Distilled lessons that survived qualify/improve review; one bullet per lesson |
+| Daily log | `.oh/memory/YYYY-MM-DD/log.md` | Time-stamped entries from each skill or agent run that day |
+| Long-term lessons | `.oh/memory/MEMORY.md` | Distilled lessons that survived qualify/improve review; one bullet per lesson |
 
 Topic notes (e.g. campaign planning, integration state) go directly under
-`memory/<topic>.md` (example: `memory/x-campaign.md`). They are neither daily
+`.oh/memory/<topic>.md` (example: `.oh/memory/x-campaign.md`). They are neither daily
 nor long-term: they are reference notes an agent would otherwise re-derive from
 scratch.
 
@@ -24,46 +24,46 @@ minimum record needed to avoid repeating the same mistakes across sessions.
 ## Layout
 
 ```
-memory/
+.oh/memory/
   MEMORY.md              # long-term lessons (tracked)
   <topic>.md             # per-topic reference notes (tracked or gitignored per need)
   YYYY-MM-DD/
     log.md               # daily append log (gitignored - local-only; not committed)
 ```
 
-The `memory/YYYY-MM-DD/` directory is gitignored via `.gitignore`'s
-`memory/[0-9]*/` rule, so daily logs are a **local-only working journal** —
+The `.oh/memory/YYYY-MM-DD/` directory is gitignored via `.gitignore`'s
+`.oh/memory/[0-9]*/` rule, so daily logs are a **local-only working journal** —
 they do not survive a fresh clone. Only `MEMORY.md`, `README.md`, and explicitly reviewed topic notes should
 persist in git. Public release branches should not carry daily logs or
 maintainer-private notes.
 
 Date format: always `date -u +%Y-%m-%d` (UTC). Never local time.
 
-The `memory/YYYY-MM-DD/` subdirectory is the canonical path. The heartbeat cron
-writes there; using a flat `memory/YYYY-MM-DD.md` file is incorrect — the
+The `.oh/memory/YYYY-MM-DD/` subdirectory is the canonical path. The heartbeat cron
+writes there; using a flat `.oh/memory/YYYY-MM-DD.md` file is incorrect — the
 subdirectory won in practice. Create the directory before writing:
 
 ```bash
 TODAY=$(date -u +%Y-%m-%d)
-mkdir -p "memory/$TODAY"
-# then append to memory/$TODAY/log.md
+mkdir -p ".oh/memory/$TODAY"
+# then append to .oh/memory/$TODAY/log.md
 ```
 
 For directory anchor and gitignore conventions see `context/directory-readme.md`.
 
 ## Read
 
-**Orchestrator (full session):** `memory/MEMORY.md` is listed in `CLAUDE.md`
+**Orchestrator (full session):** `.oh/memory/MEMORY.md` is listed in `CLAUDE.md`
 under "Session start" and is auto-loaded at the top of every session alongside
 `context/SOUL.md`, `context/IDENTITY.md`, `context/TOOLS.md`, and
 `context/USER.md`. No explicit read step needed.
 
 **Sub-agents (on demand):** Sub-agents do not auto-load memory. When a briefing
 is relevant, the advisor should include the pertinent excerpt or instruct the
-sub-agent to read `memory/MEMORY.md` and `memory/<today>/log.md` as its first
+sub-agent to read `.oh/memory/MEMORY.md` and `.oh/memory/<today>/log.md` as its first
 step.
 
-**Heartbeat cron:** The hourly heartbeat reads `memory/<today>/log.md` at the
+**Heartbeat cron:** The hourly heartbeat reads `.oh/memory/<today>/log.md` at the
 start of each pulse (creating the directory if it does not exist) and appends a
 result entry. See `crons/heartbeat.md` for the full heartbeat spec.
 
@@ -71,7 +71,7 @@ result entry. See `crons/heartbeat.md` for the full heartbeat spec.
 
 Run at the end of **every** skill or agent execution — op, dry-run, or error.
 
-**a) Log** — append to `memory/YYYY-MM-DD/log.md`:
+**a) Log** — append to `.oh/memory/YYYY-MM-DD/log.md`:
 
 ```markdown
 ## <Skill-Name> -- HH:MM UTC
@@ -92,7 +92,7 @@ produced the entry.
 - Did the run reveal a coupling, constraint, or edge case not captured in any rule?
 - Would the next agent start better if this were written down?
 
-**c) Improve** — if actionable, append to `memory/MEMORY.md` under
+**c) Improve** — if actionable, append to `.oh/memory/MEMORY.md` under
 `## Lessons Learned`. Keep each lesson to one bullet. Lessons that already
 appear in `context/IDENTITY.md` or an existing rule must not be duplicated —
 link or skip.
@@ -103,7 +103,7 @@ is an incomplete execution.
 ## Concurrency
 
 Memory files are plain markdown. Shared runtime logs — especially
-`memory/<today>/log.md` and `crons/.cron.log` written from cron, isolated
+`.oh/memory/<today>/log.md` and `crons/.cron.log` written from cron, isolated
 worktrees, or kept tmux sessions — should append through
 `scripts/locked-append.sh` (or an equivalent `flock`-guarded helper) so a whole
 multi-line record is serialized. Local scratch writes that only one process can
@@ -141,16 +141,16 @@ is not: treat existing entries as immutable once written.
 
 ## Boundary with `context/IDENTITY.md`
 
-`context/IDENTITY.md` and `memory/MEMORY.md` are related but distinct:
+`context/IDENTITY.md` and `.oh/memory/MEMORY.md` are related but distinct:
 
-| | `context/IDENTITY.md` | `memory/MEMORY.md` |
+| | `context/IDENTITY.md` | `.oh/memory/MEMORY.md` |
 |-|-----------------------|--------------------|
 | **Holds** | Operating principles — how the orchestrator behaves; distilled rules-of-thumb | Experiential observations — what specific runs revealed |
 | **Tone** | Prescriptive ("always do X", "never do Y") | Descriptive ("run on YYYY-MM-DD showed that…") |
 | **Written by** | Orchestrator sessions, after deliberate review | Any session or skill, immediately after a run |
 | **Changed how** | Deliberate revision when evidence overturns a principle | Append-only; entries are never edited after writing |
 
-A lesson graduates from `memory/MEMORY.md` to `context/IDENTITY.md` only when
+A lesson graduates from `.oh/memory/MEMORY.md` to `context/IDENTITY.md` only when
 it has generalized into a principle — that is, it applies across contexts, not
 just the run that produced it. Do not double-write: once a lesson is in
 `IDENTITY.md`, remove or link it from `MEMORY.md`.
@@ -165,5 +165,5 @@ goes in `IDENTITY.md`.
 |----------|------|
 | Directory README convention | `context/directory-readme.md` |
 | Heartbeat cron (daily log writer) | `crons/heartbeat.md` |
-| Long-term lessons (instance) | `memory/MEMORY.md` |
+| Long-term lessons (instance) | `.oh/memory/MEMORY.md` |
 | Identity / operating principles | `context/IDENTITY.md` |

--- a/skills/retro/scripts/check-memory-duplicates.sh
+++ b/skills/retro/scripts/check-memory-duplicates.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 # Reads proposed MEMORY/IDENTITY lines from stdin and reports lines whose lesson
-# text already appears in memory/MEMORY.md or context/IDENTITY.md. Exact enough to
+# text already appears in .oh/memory/MEMORY.md or context/IDENTITY.md. Exact enough to
 # catch double-writes without making subjective semantic judgments.
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
-MEMORY_FILE="$ROOT/memory/MEMORY.md"
+MEMORY_FILE="$ROOT/.oh/memory/MEMORY.md"
 IDENTITY_FILE="$ROOT/context/IDENTITY.md"
 
 status=0

--- a/skills/rlm/SKILL.md
+++ b/skills/rlm/SKILL.md
@@ -145,10 +145,10 @@ Write the recursion trace (chunk map used, per-chunk sub-agent findings, the
 to the **gitignored** path:
 
 ```
-memory/<UTC-date>/rlm-<slug>-<HHMMSS>.json     # UTC-date = date -u +%Y-%m-%d
+.oh/memory/<UTC-date>/rlm-<slug>-<HHMMSS>.json     # UTC-date = date -u +%Y-%m-%d
 ```
 
-Then append a one-line entry to `memory/<UTC-date>/log.md` per the Memory Improvement
+Then append a one-line entry to `.oh/memory/<UTC-date>/log.md` per the Memory Improvement
 Protocol (`.mifune/skills/retro/references/memory-protocol.md`). The trace makes the
 recursion auditable; it is a consumption artifact, never staged or committed. Announce
 `RESULT: RLM-COMPLETE`.

--- a/skills/skill-lint/SKILL.md
+++ b/skills/skill-lint/SKILL.md
@@ -66,7 +66,7 @@ AGE_DAYS=$(( (NOW - MTIME) / 86400 ))
 ```bash
 # Count daily memory logs that mention this skill name (case-insensitive)
 SKILL_NAME="<skill-name>"
-MENTION_COUNT=$(grep -rli "$SKILL_NAME" /home/sandbox/harness/memory/ 2>/dev/null | wc -l)
+MENTION_COUNT=$(grep -rli "$SKILL_NAME" /home/sandbox/harness/.oh/memory/ 2>/dev/null | wc -l)
 ```
 
 | Mentions | Score |
@@ -194,7 +194,7 @@ Sort the Scores table by Total ascending (worst first). Omit CURRENT skills from
 
 ### 7. Memory Protocol
 
-Append to `memory/YYYY-MM-DD/log.md` where today = `date -u +%Y-%m-%d`:
+Append to `.oh/memory/YYYY-MM-DD/log.md` where today = `date -u +%Y-%m-%d`:
 
 ```markdown
 ## [Skill Lint] — HH:MM UTC

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -86,7 +86,7 @@ esac
   `STATUS: SPEC-RETRO-DONE`. Never infer success from silence — a missing
   artifact, crashed build, or undecided gate emits no `STATUS:` line.
 - **Memory Improvement Protocol** — every invocation of every subcommand appends
-  a log entry to `memory/<UTC-date>/log.md` under `## spec-<sub> -- HH:MM UTC`,
+  a log entry to `.oh/memory/<UTC-date>/log.md` under `## spec-<sub> -- HH:MM UTC`,
   then runs the qualify/improve pass per `.mifune/skills/retro/references/memory-protocol.md`. No exceptions.
 
 ## When NOT to use

--- a/skills/spec/references/critique.md
+++ b/skills/spec/references/critique.md
@@ -73,7 +73,7 @@ at `/spec plan` and emit no `STATUS:` line (a missing spec is a failure, not a c
 ## Memory Protocol
 
 `/critique` and `/approve` each append their own log entry. `critique` adds one
-roll-up line to `memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
+roll-up line to `.oh/memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
 
 ```markdown
 ## spec-critique -- HH:MM UTC

--- a/skills/spec/references/execute.md
+++ b/skills/spec/references/execute.md
@@ -91,7 +91,7 @@ propose-then-confirm gate. Always logs.
 The self-improvement tail (`AGENTS.md § The Workflow`):
 
 - **compound** — promote durable knowledge so it is reused, not re-derived (`/wiki ingest`,
-  `memory/MEMORY.md`, mint a probe from any guardrail lesson).
+  `.oh/memory/MEMORY.md`, mint a probe from any guardrail lesson).
 - **compress** — keep the always-loaded context lean and clear (`/context-audit`).
 - **benchmark** — confirm the change earned its complexity (`/benchmark`): the `/eval`
   regression floor stays green AND the capability-benchmark ceiling held or moved.
@@ -125,7 +125,7 @@ Workflow`: *human merge — final gate, no auto-merge*). Never `gh pr merge`.
 ## Memory Protocol
 
 The composed skills each log their own entries. `execute` adds one roll-up to
-`memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
+`.oh/memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
 
 ```markdown
 ## spec-execute -- HH:MM UTC

--- a/skills/spec/references/plan.md
+++ b/skills/spec/references/plan.md
@@ -104,7 +104,7 @@ done
 
 ## Memory Protocol
 
-After a run, append to `memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
+After a run, append to `.oh/memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
 
 ```markdown
 ## spec-plan -- HH:MM UTC

--- a/skills/spec/references/retro.md
+++ b/skills/spec/references/retro.md
@@ -12,7 +12,7 @@ lessons.
 
 **Core principle: compose `/retro`, scoped to this task.** `/retro` already implements the
 scientific session-closing pass — falsifiable hypotheses, evidence for *and* against, a
-verdict + confidence, and a propose-then-confirm promotion into `memory/MEMORY.md` /
+verdict + confidence, and a propose-then-confirm promotion into `.oh/memory/MEMORY.md` /
 `context/IDENTITY.md`. `retro` is the execution-side application of it: point `/retro`
 at the just-built `tasks/<slug>/` run so the reflection is anchored to that unit's
 artifacts (`prd.md`, `progress.txt`, `prd.json`, `critique.md`, the `/audit` evidence)
@@ -66,7 +66,7 @@ still require explicit approval (or are skipped under `--dry-run`).
 ## Memory Protocol
 
 `/retro` writes its own log entry. `retro` ensures it is tagged to the unit; if `/retro`
-did not, add one line to `memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
+did not, add one line to `.oh/memory/<UTC-date>/log.md` per `.mifune/skills/retro/references/memory-protocol.md`:
 
 ```markdown
 ## spec-retro -- HH:MM UTC

--- a/skills/strategic-proposal/SKILL.md
+++ b/skills/strategic-proposal/SKILL.md
@@ -203,7 +203,7 @@ Parse the council's FINAL roadmap table and write it to `docs/roadmap.md` as a s
 
 ### 10. Memory Improvement Protocol
 
-**a) Log** — append to `memory/YYYY-MM-DD/log.md` where today = `date -u +%Y-%m-%d`:
+**a) Log** — append to `.oh/memory/YYYY-MM-DD/log.md` where today = `date -u +%Y-%m-%d`:
 
 ```markdown
 ## Strategic Proposal — HH:MM UTC
@@ -236,4 +236,4 @@ See `.mifune/skills/retro/references/memory-protocol.md` for the canonical Memor
 | Roadmap data | `docs/roadmap.md` |
 | Identity | `IDENTITY.md` |
 | Memory | `MEMORY.md` |
-| Daily Logs | `memory/YYYY-MM-DD/log.md` |
+| Daily Logs | `.oh/memory/YYYY-MM-DD/log.md` |

--- a/skills/sync/references/publish.md
+++ b/skills/sync/references/publish.md
@@ -73,7 +73,7 @@ git rm -r --cached --ignore-unmatch tasks/*/  # remove sub-dirs if any leaked
 git checkout upstream/development -- .mifune/skills/wiki/corpus/ 2>/dev/null || \
   git checkout upstream/development -- .claude/skills/wiki/corpus/ 2>/dev/null || true
 # Agent identity files — keep public stubs only
-git checkout upstream/development -- memory/MEMORY.md
+git checkout upstream/development -- .oh/memory/MEMORY.md
 git checkout upstream/development -- context/IDENTITY.md
 git checkout upstream/development -- context/SOUL.md
 git checkout upstream/development -- context/USER.md
@@ -81,14 +81,14 @@ git checkout upstream/development -- context/TOOLS.md
 # Agent folders (docs/agents/, tasks/archive/) if present
 git checkout upstream/development -- docs/agents/ 2>/dev/null || true
 # Daily memory logs (gitignored locally, but check)
-git checkout upstream/development -- memory/ 2>/dev/null || true
+git checkout upstream/development -- .oh/memory/ 2>/dev/null || true
 # Codex plans / local promotion notes
 git checkout upstream/development -- .codex/plans/ 2>/dev/null || true
 ```
 
 Verify each sanitized path is clean:
 ```bash
-git diff upstream/development HEAD -- tasks/ memory/ context/ .codex/plans/
+git diff upstream/development HEAD -- tasks/ .oh/memory/ context/ .codex/plans/
 ```
 Output must be empty. If not, inspect the diff and reset the leaking paths.
 

--- a/skills/weigh/SKILL.md
+++ b/skills/weigh/SKILL.md
@@ -112,7 +112,7 @@ For each sampled trajectory, attach the deterministic signals the scorer weights
 
 Write the assembled cohort (array of `TRAJECTORY_SCHEMA` records, or a
 `{ "trajectories": [...] }` wrapper) to a gitignored working file, e.g.
-`memory/<UTC-date>/weigh-<slug>-<HHMMSS>.cohort.json`.
+`.oh/memory/<UTC-date>/weigh-<slug>-<HHMMSS>.cohort.json`.
 
 ### Step 4 — Weight + select (the harness-owned step)
 
@@ -122,7 +122,7 @@ scorer itself stays pure:
 
 ```bash
 node "${CLAUDE_SKILL_DIR}/scripts/score-trajectories.mjs" \
-  --cohort "memory/$(date -u +%F)/weigh-<slug>-<HHMMSS>.cohort.json" \
+  --cohort ".oh/memory/$(date -u +%F)/weigh-<slug>-<HHMMSS>.cohort.json" \
   --method "<best-of-n|vote|softmax|synthesis>" \
   --now "$(date -u +%s)" \
   [--weights '<json>'] [--soft]
@@ -147,8 +147,8 @@ methods `selected` is already the single chosen id — no aggregation step.
 
 ### Step 6 — Persist + log
 
-1. **Persist** the run artifacts to the **gitignored** `memory/<UTC-date>/`
-   directory (matched by `.gitignore` `memory/[0-9]*/`) — never stage them:
+1. **Persist** the run artifacts to the **gitignored** `.oh/memory/<UTC-date>/`
+   directory (matched by `.gitignore` `.oh/memory/[0-9]*/`) — never stage them:
    - `weigh-<slug>-<HHMMSS>.json` — the full scorer report (config + scored rows +
      selection), the audit trail.
    - `weigh-<slug>-<HHMMSS>.md` — a short human summary: the task, N, method,
@@ -156,7 +156,7 @@ methods `selected` is already the single chosen id — no aggregation step.
      any `floorViolations`.
 
 2. **Log** per the Memory Improvement Protocol — append to
-   `memory/<UTC-date>/log.md` (today = `date -u +%Y-%m-%d`):
+   `.oh/memory/<UTC-date>/log.md` (today = `date -u +%Y-%m-%d`):
 
    ```markdown
    ## weigh -- HH:MM UTC
@@ -184,7 +184,7 @@ Announce the `RESULT:` tag once Step 6 completes.
   the scorer.
 - **Exceeding the cap.** `N > 8` is rejected — cost grows linearly with N (plus
   `/eval` + `/audit` per trajectory). Preview with `--dry-run` first.
-- **Committing the artifacts.** `memory/<UTC-date>/` is gitignored; never stage a
+- **Committing the artifacts.** `.oh/memory/<UTC-date>/` is gitignored; never stage a
   cohort, report, or summary.
 - **Editing the scorer to change weights inline.** `DEFAULT_WEIGHTS` is
   `Object.freeze`d and probe-pinned; pass `--weights` for a one-off, and route any

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -78,7 +78,7 @@ These hold across all three subcommands; the reference docs assume them.
   ```
 - **Orchestrator-only write gate**: `ingest` writes (snapshots + entity pages) and
   `lint`'s `corpus/README.md` regeneration are orchestrator-only. Sub-agents propose
-  drafts to `memory/<today>/wiki-drafts/<slug>.md`; the orchestrator promotes via
+  drafts to `.oh/memory/<today>/wiki-drafts/<slug>.md`; the orchestrator promotes via
   `/wiki ingest --from-draft <slug>`. A sub-agent that writes directly to the corpus
   is out of scope and may be reverted.
 - **Index reflects tracked entries**: `corpus/README.md`'s Index table is generated
@@ -90,7 +90,7 @@ These hold across all three subcommands; the reference docs assume them.
 ## When NOT to use
 
 - A topic that is a **behavioral norm** ("always do X") → a rule/skill, not the wiki.
-- A **session journal** entry ("this run showed Y") → `memory/`, not the wiki.
+- A **session journal** entry ("this run showed Y") → `.oh/memory/`, not the wiki.
 - **Human-facing prose** → `docs/`, not the wiki (the wiki is LLM-readable synthesis).
 - Full-text body search → direct `grep`; `query` is intentionally frontmatter-only.
 

--- a/skills/wiki/references/concurrent-ingest-worktrees.md
+++ b/skills/wiki/references/concurrent-ingest-worktrees.md
@@ -12,7 +12,7 @@ Use this reference when an `add to wiki` request arrives while the main checkout
    - create `.mifune/skills/wiki/corpus/raw/<date>-<slug>.md` as local provenance
    - create/update `.mifune/skills/wiki/corpus/<slug>.md`
    - regenerate `.mifune/skills/wiki/corpus/README.md` via `/wiki lint` or the atomic fallback
-   - append `memory/<date>/log.md`
+   - append `.oh/memory/<date>/log.md`
 4. Commit and push only the tracked deliverables, normally `.mifune/skills/wiki/corpus/<slug>.md` and `.mifune/skills/wiki/corpus/README.md`.
 5. In the final report, name the worktree path, branch, commit, and note any gitignored provenance files.
 

--- a/skills/wiki/references/ingest.md
+++ b/skills/wiki/references/ingest.md
@@ -8,7 +8,7 @@
 
 # Wiki Ingest
 
-Snapshot a source and write or update a wiki entity page. This is the only authorized path for writing to `.mifune/skills/wiki/corpus/`. Sub-agents may not call this skill directly for write operations — they propose drafts to `memory/<today>/wiki-drafts/<slug>.md` and the orchestrator promotes via `--from-draft`.
+Snapshot a source and write or update a wiki entity page. This is the only authorized path for writing to `.mifune/skills/wiki/corpus/`. Sub-agents may not call this skill directly for write operations — they propose drafts to `.oh/memory/<today>/wiki-drafts/<slug>.md` and the orchestrator promotes via `--from-draft`.
 
 The canonical schema, slug derivation rules, and body-merge strategy all live in `.mifune/skills/wiki/references/schema.md`. This skill defers to those rules — it does not redefine them.
 
@@ -38,7 +38,7 @@ No other forms are documented or supported. `argument-hint` frontmatter above en
 /wiki ingest --from-draft <slug> [--allow-stale]
 ```
 
-- `--from-draft <slug>` — promote the most-recent draft for `<slug>` from `memory/*/wiki-drafts/<slug>.md`.
+- `--from-draft <slug>` — promote the most-recent draft for `<slug>` from `.oh/memory/*/wiki-drafts/<slug>.md`.
 - `--allow-stale` — bypass the 7-day staleness gate (see § Draft promotion).
 
 ## When to use
@@ -156,16 +156,16 @@ When the source URL is a GitHub repository and the user asks to "study", "index 
 
 ### 5. Draft promotion (`--from-draft`)
 
-1. Glob for draft files: `memory/*/wiki-drafts/<slug>.md`. Exclude any file named `<slug>.md.skip`.
-2. Sort matches by the **ISO date component in the parent directory name** (`memory/YYYY-MM-DD/`) — take the lexicographically greatest date. Do **not** use filesystem mtime (unreliable across git checkout and Docker volume mounts).
+1. Glob for draft files: `.oh/memory/*/wiki-drafts/<slug>.md`. Exclude any file named `<slug>.md.skip`.
+2. Sort matches by the **ISO date component in the parent directory name** (`.oh/memory/YYYY-MM-DD/`) — take the lexicographically greatest date. Do **not** use filesystem mtime (unreliable across git checkout and Docker volume mounts).
 3. If no matches, exit:
    ```
-   ERROR: no draft found for slug "<slug>" under memory/*/wiki-drafts/.
+   ERROR: no draft found for slug "<slug>" under .oh/memory/*/wiki-drafts/.
    ```
 4. **Staleness check**: compute the difference between today's UTC date and the most-recent draft's parent directory date. If the draft date is more than 7 days older than today:
    - Without `--allow-stale`: exit with status STALE:
      ```
-     STALE: draft memory/<date>/wiki-drafts/<slug>.md is <N> days old (threshold: 7 days).
+     STALE: draft .oh/memory/<date>/wiki-drafts/<slug>.md is <N> days old (threshold: 7 days).
      Re-run with --allow-stale to promote anyway.
      ```
    - With `--allow-stale`: log a warning and continue.
@@ -250,7 +250,7 @@ If you cannot run the full `/wiki lint` skill, do not hand-maintain the table ca
 
 This skill's write operations (`.mifune/skills/wiki/corpus/raw/` snapshots and `.mifune/skills/wiki/corpus/<slug>.md` writes) are **orchestrator-only**. The orchestrator is the only session authorized to write to tracked wiki surfaces.
 
-Sub-agents may propose new entries by writing drafts to `memory/<today>/wiki-drafts/<slug>.md`. The draft format is free-form markdown (no required frontmatter). The orchestrator then reviews and promotes via:
+Sub-agents may propose new entries by writing drafts to `.oh/memory/<today>/wiki-drafts/<slug>.md`. The draft format is free-form markdown (no required frontmatter). The orchestrator then reviews and promotes via:
 
 ```
 /wiki ingest --from-draft <slug>
@@ -265,10 +265,10 @@ Always run this step, regardless of outcome. Get the current UTC time:
 ```bash
 date -u +%H:%M
 TODAY=$(date -u +%Y-%m-%d)
-mkdir -p "memory/$TODAY"
+mkdir -p ".oh/memory/$TODAY"
 ```
 
-Append to `memory/<UTC-date>/log.md`:
+Append to `.oh/memory/<UTC-date>/log.md`:
 
 ```markdown
 ## /wiki ingest -- HH:MM UTC
@@ -276,7 +276,7 @@ Append to `memory/<UTC-date>/log.md`:
 - **Source**: <url or path or draft slug>
 - **Slug-Created**: <slug> | —
 - **Slugs-Updated**: <slug> | —
-- **Snapshot-Path**: <.mifune/skills/wiki/corpus/raw/yyyy-mm-dd-slug.md> | <memory/.../wiki-drafts/slug.md> | —
+- **Snapshot-Path**: <.mifune/skills/wiki/corpus/raw/yyyy-mm-dd-slug.md> | <.oh/memory/.../wiki-drafts/slug.md> | —
 - **Observation**: <one sentence on what was ingested or why the run failed>
 ```
 
@@ -290,14 +290,14 @@ Field guidance:
 Then apply the qualify/improve pass per `.mifune/skills/retro/references/memory-protocol.md` § Write:
 - Did the ingest reveal a slug derivation edge case not covered by `.mifune/skills/wiki/references/schema.md` § 3?
 - Did the body-merge produce an unexpected result worth capturing?
-- If yes, propose a `memory/MEMORY.md` addition.
+- If yes, propose a `.oh/memory/MEMORY.md` addition.
 
 ## Anti-patterns
 
 - **Monolithic ingest scripts when a safety gate is likely** — avoid bundling network fetch, raw snapshot write, wiki synthesis, and log append into one large `execute_code` call. If approval or shell-safety friction appears, split the ingest into auditable steps: fetch/snapshot with a small `terminal` command, create or update `.mifune/skills/wiki/corpus/<slug>.md` with `write_file`/`patch`, then append the memory log separately. The invariant is the same (raw snapshot + bounded synthesized entry + log), but smaller tool calls are easier to approve, verify, and recover.
 - **Consent-gated write recovery** — if a multi-file ingest is blocked by a consent/approval gate, report exactly which files would be written and wait for explicit approval. Prefer splitting the approved recovery into the smallest direct file operations (`write_file` for the wiki entry/raw snapshots, `patch`/append for the log) rather than wrapping all writes in `execute_code`; approval state may not carry cleanly into a monolithic script retry. If the tool explicitly says not to retry or not to attempt the same outcome via another tool, stop and report the blocker. Otherwise, after approval, complete the intended ingest and verify the synthesized wiki entry, the raw snapshot size, and the log entry before declaring success. Do not treat the pre-approval fetch metadata as an ingest; no wiki operation is complete until raw snapshot + entity page + log all exist.
 - **Writing directly to `.mifune/skills/wiki/corpus/` from a sub-agent context** — always use the draft path + `--from-draft` promotion. The orchestrator is the sole writer.
-- **Hardcoding today's date in `--from-draft` resolution** — glob `memory/*/wiki-drafts/<slug>.md` and sort by the ISO date in the directory name, not by mtime and not by assuming today.
+- **Hardcoding today's date in `--from-draft` resolution** — glob `.oh/memory/*/wiki-drafts/<slug>.md` and sort by the ISO date in the directory name, not by mtime and not by assuming today.
 - **Using mtime for stale detection** — mtime is unreliable across git checkouts and Docker volume remounts. Always derive staleness from the ISO date in the parent directory name.
 - **Omitting `mkdir -p .mifune/skills/wiki/corpus/raw/`** — `.mifune/skills/wiki/corpus/raw/` is gitignored and may not exist on a fresh clone. Always create it before writing.
 - **Concatenating bodies on update** — the body-merge strategy replaces `## Summary` and `## Detail` in-place; it does not append. Bodies that grow unbounded exceed the 600-word cap and dilute the entry.
@@ -328,6 +328,6 @@ This smoke test is not run in CI. Run it manually after the skill is committed, 
 Expected outcome:
 - `.mifune/skills/wiki/corpus/raw/<today>-karpathy-llm-wiki.md` exists with `# Source: https://gist.github.com/...` header.
 - `.mifune/skills/wiki/corpus/karpathy-llm-wiki.md` exists with valid frontmatter, `confidence: provisional`, and the snapshot path in `sources:`.
-- `memory/<today>/log.md` has an `## /wiki ingest -- HH:MM UTC` entry with `Result: OP`.
+- `.oh/memory/<today>/log.md` has an `## /wiki ingest -- HH:MM UTC` entry with `Result: OP`.
 
 This smoke test MUST run and its commit must land before US-003's smoke test runs.

--- a/skills/wiki/references/lint.md
+++ b/skills/wiki/references/lint.md
@@ -420,10 +420,10 @@ UTC time first:
 ```bash
 date -u +%H:%M
 TODAY=$(date -u +%Y-%m-%d)
-mkdir -p "$HARNESS/memory/$TODAY"
+mkdir -p "$HARNESS/.oh/memory/$TODAY"
 ```
 
-Append to `memory/<UTC-date>/log.md`:
+Append to `.oh/memory/<UTC-date>/log.md`:
 
 ```markdown
 ## /wiki lint -- HH:MM UTC
@@ -454,7 +454,7 @@ Then apply the qualify/improve loop per `.mifune/skills/retro/references/memory-
 
 - Did any finding reveal a gap in the wiki schema or cross-link conventions?
 - Did the atomic write step surface an edge case worth capturing?
-- If yes, propose a `memory/MEMORY.md` addition.
+- If yes, propose a `.oh/memory/MEMORY.md` addition.
 
 See `.mifune/skills/retro/references/memory-protocol.md` for the canonical Memory Improvement Protocol.
 

--- a/skills/wiki/references/query.md
+++ b/skills/wiki/references/query.md
@@ -222,10 +222,10 @@ Always run this step regardless of match count. Get UTC time first:
 ```bash
 date -u +%H:%M
 TODAY=$(date -u +%Y-%m-%d)
-mkdir -p "$HARNESS/memory/$TODAY"
+mkdir -p "$HARNESS/.oh/memory/$TODAY"
 ```
 
-Append to `memory/<UTC-date>/log.md`:
+Append to `.oh/memory/<UTC-date>/log.md`:
 
 ```markdown
 ## /wiki query -- HH:MM UTC

--- a/skills/wiki/references/schema.md
+++ b/skills/wiki/references/schema.md
@@ -14,8 +14,8 @@ The sharp test: *Is this a fact or synthesis about a topic, intended to be read 
 | --- | --- | --- | --- |
 | `.mifune/skills/*/SKILL.md` | Behavioral norms (prescriptive) | Deliberate orchestrator revision | Wiki holds **facts**, skills hold **how to behave** |
 | `context/IDENTITY.md` | Cross-session operating principles | Orchestrator, deliberate | Wiki is codebase/domain knowledge; IDENTITY is "always do X" |
-| `memory/MEMORY.md` | Distilled experiential lessons ("run on date X showed Y") | Orchestrator via `/retro` | Wiki entries are **reference**; memory is **journal** |
-| `memory/<topic>.md` | Ad-hoc reference notes, no schema, no retrieval | Any session | Wiki wins after a note is re-derived twice and earns a schema |
+| `.oh/memory/MEMORY.md` | Distilled experiential lessons ("run on date X showed Y") | Orchestrator via `/retro` | Wiki entries are **reference**; memory is **journal** |
+| `.oh/memory/<topic>.md` | Ad-hoc reference notes, no schema, no retrieval | Any session | Wiki wins after a note is re-derived twice and earns a schema |
 | `docs/` | Human-facing prose | Orchestrator / contributors | Wiki is LLM-readable; docs are human-readable |
 | `.claude/skills/*/SKILL.md` | Executable procedures | Orchestrator | Skills are *how to do*; wiki is *what is true* |
 | `.mifune/skills/wiki/corpus/raw/` | Immutable source captures (snapshots of fetched pages, papers) | Skills writing snapshots only | Same surface; raw is upstream, wiki entries are synthesis |
@@ -37,9 +37,9 @@ created: 2026-05-23
 updated: 2026-05-23
 sources:
   - raw/2026-05-23-github-docs-fine-grained-pat.md
-  # aspirational: memory/MEMORY.md heading anchors are not stable today;
+  # aspirational: .oh/memory/MEMORY.md heading anchors are not stable today;
   # once MEMORY.md gains stable anchors, entries may cite them as:
-  #   - memory/MEMORY.md#<anchor>
+  #   - .oh/memory/MEMORY.md#<anchor>
 related: [github-auth-sandbox, ci-secrets-handling]
 confidence: confirmed   # provisional | confirmed | deprecated
 ---


### PR DESCRIPTION
Paired submodule change for the parent **memory/ → .oh/memory/** relocation in `mifunedev/openharness` (one of the four `context`/`evals`/`crons`/`memory` relocations into the `.oh/` machinery namespace).

## What
Repoints skill/agent references to the harness memory directory from `memory/` to `.oh/memory/`:
- `skills/autopilot/autopilot-caps.sh` — liveness/memory-block paths (`mkdir -p "$root/.oh/memory/$day"`, log path)
- `skills/harness-audit/SKILL.md` — `$AUDIT_LOG_ROOT/.oh/memory/MEMORY.md` durable read
- `skills/retro`, `render-html`, `prompt-miner`, `memory-protocol.md` — memory tiers + topic-file paths (`.oh/memory/<topic>.md`)

## Not changed
- **Prose `memory/<word>` separators** ("memory/disk", "memory/identity", "memory/liveness", "memory/doc") — these mean "memory and X", not a path; left intact.
- `skills/wiki/corpus/**` (gitignored research corpus).

Consumed by the parent PR via a gitlink bump. The parent's coupled probes (`harness-audit-shared-memory`, `memory-log-locked-append`, `autopilot-worktree-log-root`, etc.) pass against the bumped gitlink.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>